### PR TITLE
Added a .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,6 @@
 * text=auto
 
-/tests export-ignore
+/spec export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.travis.yml export-ignore


### PR DESCRIPTION
This is so when people are installing this through composer, they only get the required source files. This saves disk space for the user, and saves github's bandwidth.
