### PR TITLE
Use a better version constraint in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Or edit `composer.json` and add:
 ```json
 {
     "require": {
-        "toin0u/digitalocean-v2": "@stable"
+        "toin0u/digitalocean-v2": "0.1.*"
     }
 }
 ```


### PR DESCRIPTION
Using `@stable` is such a bad practice since it's basically the equivalent of `*`.

I've changed it to `0.1.*`. Once this package reaches 1.0.0, we can change it to `~1.0`.

`~1.0` means get any 1.x that is 1.0.0 or greater. `~1.4` means get any 1.x that is 1.4.0 or greater.

Using `~1.0` on the readme means the user can increment the minor version themselves to satisfy the minimum version they'd like to get the features they want.
