### PR TITLE
Backup windows on droplets can be null, so check for that. Fixes #82

### DIFF
--- a/src/Entity/NextBackupWindow.php
+++ b/src/Entity/NextBackupWindow.php
@@ -25,4 +25,18 @@ class NextBackupWindow extends AbstractEntity
      * @var string
      */
     public $end;
+
+    /**
+     * Build a new backup window instance
+     *
+     * @param \stdClass|array|null $parameters
+     */
+    public function build($parameters)
+    {
+        if (is_null($parameters)) {
+            return;
+        }
+
+        parent::build($parameters);
+    }
 }


### PR DESCRIPTION
NextBackupWindow was being built with `null` as the value, as after digitalocean made backups on droplets optional, the backup window can be `null` instead of an object (which would mean an `array|stdClass` that can be looped)

The PR fixes the warning generated when retrieving droplets without backups enabled. This is a PHP warning, and on almost all frameworks (including laravel, which is where i encountered this), that warning is an exception.