### PR TITLE
Check if region is an object

### DIFF
--- a/src/Entity/Action.php
+++ b/src/Entity/Action.php
@@ -69,7 +69,7 @@ class Action extends AbstractEntity
         parent::build($parameters);
 
         foreach ($parameters as $property => $value) {
-            if ('region' === $property) {
+            if ('region' === $property && is_object($value)) {
                 $this->region = new Region($value);
 
                 continue;

--- a/src/Entity/Droplet.php
+++ b/src/Entity/Droplet.php
@@ -158,7 +158,9 @@ class Droplet extends AbstractEntity
                     break;
 
                 case 'region':
-                    $this->region = new Region($value);
+                    if(is_object($value)) {
+                        $this->region = new Region($value);
+                    }
                     break;
 
                 case 'image':


### PR DESCRIPTION
I was testing the new version out on a project and encountered an error where the region was returning null.

In the docs it says that the region attribute for action can be nullable.

https://developers.digitalocean.com/documentation/v2/#image-actions

This pull request checks if the value is an object so it can be send into the constructor of the Region class.