### PR TITLE
Removed useless "continue;"

### DIFF
--- a/src/Entity/Action.php
+++ b/src/Entity/Action.php
@@ -71,8 +71,6 @@ class Action extends AbstractEntity
         foreach ($parameters as $property => $value) {
             if ('region' === $property && is_object($value)) {
                 $this->region = new Region($value);
-
-                continue;
             }
         }
     }


### PR DESCRIPTION
This `continue;` does nothing because it just says move on to the next element in the iteration, which we were doing anyway. Am I missing something?