### PR TITLE
Remove unnecessary header

### DIFF
--- a/src/Adapter/Guzzle5Adapter.php
+++ b/src/Adapter/Guzzle5Adapter.php
@@ -70,7 +70,6 @@ class Guzzle5Adapter extends AbstractAdapter implements AdapterInterface
      */
     public function put($url, array $headers = array(), $content = '')
     {
-        $headers['content-type'] = 'application/json';
         $options = array('headers' => $headers, 'body' => $content);
         $request = $this->client->put($url, $options);
         $this->response = $request;
@@ -83,7 +82,6 @@ class Guzzle5Adapter extends AbstractAdapter implements AdapterInterface
      */
     public function post($url, array $headers = array(), $content = '')
     {
-        $headers['content-type'] = 'application/json';
         $options = array('headers' => $headers, 'body' => $content);
         $request = $this->client->post($url, $options);
         $this->response = $request;

--- a/src/Adapter/GuzzleAdapter.php
+++ b/src/Adapter/GuzzleAdapter.php
@@ -85,7 +85,6 @@ class GuzzleAdapter extends AbstractAdapter implements AdapterInterface
      */
     public function put($url, array $headers = array(), $content = '')
     {
-        $headers['content-type'] = 'application/json';
         $request = $this->client->put($url, $headers, $content);
         $this->response = $request->send();
 
@@ -97,7 +96,6 @@ class GuzzleAdapter extends AbstractAdapter implements AdapterInterface
      */
     public function post($url, array $headers = array(), $content = '')
     {
-        $headers['content-type'] = 'application/json';
         $request = $this->client->post($url, $headers, $content);
         $this->response = $request->send();
 


### PR DESCRIPTION
The `content-type` header is already set by the adapters. Specifying the header in here as well causes a `HTTP Error 422: Unprocessable Entity` error