### PR TITLE
Replace PHP_CodeSniffer with PHP-CS-fixer.

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -2,12 +2,14 @@
 
 require_once './vendor/autoload.php';
 
-use Symfony\CS\Finder\DefaultFinder;
 use Symfony\CS\Config\Config;
+use Symfony\CS\Finder\DefaultFinder;
+use Symfony\CS\FixerInterface;
 
 $finder = DefaultFinder::create()
     ->in('src/');
 
 return Config::create()
+    ->level(FixerInterface::SYMFONY_LEVEL)
     ->setUsingCache(true)
     ->finder($finder);

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,10 @@
+<?php
+
+require_once './vendor/autoload.php';
+
+$finder = \Symfony\CS\Finder\DefaultFinder::create()
+    ->in('src/');
+
+return \Symfony\CS\Config\Config::create()
+    ->setUsingCache(true)
+    ->finder($finder);

--- a/.php_cs
+++ b/.php_cs
@@ -2,9 +2,12 @@
 
 require_once './vendor/autoload.php';
 
-$finder = \Symfony\CS\Finder\DefaultFinder::create()
+use Symfony\CS\Finder\DefaultFinder;
+use Symfony\CS\Config\Config;
+
+$finder = DefaultFinder::create()
     ->in('src/');
 
-return \Symfony\CS\Config\Config::create()
+return Config::create()
     ->setUsingCache(true)
     ->finder($finder);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,24 +6,18 @@ Contributions are **welcome** and be fully **credited** <3
 This library will use the [Symfony2 Coding Standard](http://symfony.com/doc/current/contributing/code/standards.html).
 The easiest way to apply these conventions is to install [PHP_CodeSniffer](http://pear.php.net/package/PHP_CodeSniffer)
 and the [Opensky Symfony2 Coding Standard](https://github.com/opensky/Symfony2-coding-standard).
+These conventions are enforced using [Php-Cs-
 
-You may be interested in [PHP Coding Standards Fixer](https://github.com/fabpot/PHP-CS-Fixer).
-
-Installation
-------------
-
-``` bash
-$ pear install PHP_CodeSniffer
-$ cd `pear config-get php_dir`/PHP/CodeSniffer/Standards
-$ git clone git://github.com/opensky/Symfony2-coding-standard.git Symfony2
-$ phpcs --config-set default_standard Symfony2
-```
+These conventions are enforced using the [PHP-CS-Fixer](https://github.com/fabpot/PHP-CS-Fixer)
+tool. PHP-CS-Fixer is installed as a dev dependency and will therefore be
+available after running `composer install` or `composer update`.
 
 Usage
 -----
 
 ``` bash
-$ phpcs src/
+$ cd /path/to/DigitalOceanV2
+$ php-cs-fixer fix
 ```
 
 **Happy coding** !

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "guzzle/guzzle"     : "~3.7",
         "guzzlehttp/guzzle" : "~5.0",
         "phpspec/phpspec"   : "~2.0",
-        "fabpot/php-cs-fixer": "^1.10"
+        "fabpot/php-cs-fixer": "~1.10"
     },
 
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
         "kriswallsmith/buzz": "~0.10",
         "guzzle/guzzle"     : "~3.7",
         "guzzlehttp/guzzle" : "~5.0",
-        "phpspec/phpspec"   : "~2.0"
+        "phpspec/phpspec"   : "~2.0",
+        "fabpot/php-cs-fixer": "^1.10"
     },
 
     "suggest": {


### PR DESCRIPTION
Fixes #107.

@toin0u You should "tune" the `.php_cs` config file to specify any fixers you'd like added or removed ([PHP-CS-Fixer usage docs](https://github.com/FriendsOfPHP/PHP-CS-Fixer#usage)). Here's a sample that I use on one of the Graph Story projects:

``` php
<?php

require_once './vendor/autoload.php';

$finder = \Symfony\CS\Finder\DefaultFinder::create()
    ->in('src/');

return \Symfony\CS\Config\Config::create()
    ->setUsingCache(true)
    ->fixers([
        '-single_blank_line_before_namespace',
        '-pre_increment',
        '-concat_without_spaces',
        'concat_with_spaces',
        'ordered_use',
    ])
    ->finder($finder);
```

Without tuning the fixers, this is what gets changed: 

``` bash
$ php-cs-fixer fix --verbose
Loaded config from "/Users/jeremykendall/dev/DigitalOceanV2/.php_cs"
..F.FF....FF......F....F.....F..F..F..
Legend: ?-unknown, I-invalid file syntax, file ignored, .-no changes, F-fixed, E-error
   1) Adapter/BuzzAdapter.php (unalign_double_arrow)
   2) Adapter/Guzzle5Adapter.php (unalign_double_arrow, unalign_equals)
   3) Adapter/GuzzleAdapter.php (unalign_double_arrow, unalign_equals)
   4) Api/DomainRecord.php (multiline_array_trailing_comma)
   5) Api/Droplet.php (multiline_array_trailing_comma, single_quote, phpdoc_params)
   6) Entity/AbstractEntity.php (braces)
   7) Entity/Droplet.php (single_quote)
   8) Entity/NextBackupWindow.php (phpdoc_short_description)
   9) Entity/Size.php (phpdoc_scalar)
  10) Exception/ExceptionReader.php (unalign_equals)
Fixed all files in 5.424 seconds, 7.750 MB memory used
```