### PR TITLE
Add Guzzle 6 adapter to work alongside Guzzle 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ You then need to install **one** of the following:
 ```bash
 $ php composer.phar require kriswallsmith/buzz:~0.10
 $ php composer.phar require guzzle/guzzle:~3.7
-$ php composer.phar require guzzlehttp/guzzle:~5.0
+$ php composer.phar require guzzlehttp/guzzle:>=5.0,<7.0
 ```
 
 Or edit `composer.json` and add:
@@ -66,7 +66,7 @@ And then add **one** of the following:
     "require": {
         "kriswallsmith/buzz": "~0.10",
         "guzzle/guzzle": "~3.7",
-        "guzzlehttp/guzzle" : "~5.0"
+        "guzzlehttp/guzzle" : ">=5.0,<7.0"
     }
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require-dev": {
         "kriswallsmith/buzz": "~0.10",
         "guzzle/guzzle"     : "~3.7",
-        "guzzlehttp/guzzle" : "~5.0",
+        "guzzlehttp/guzzle" : ">=5.0,<7.0",
         "phpspec/phpspec"   : "~2.0",
         "fabpot/php-cs-fixer": "~1.10"
     },
@@ -41,7 +41,7 @@
     "suggest": {
         "kriswallsmith/buzz": "To use BuzzAdapter, require kriswallsmith/buzz:~0.10.",
         "guzzle/guzzle"     : "To use GuzzleAdapter, require guzzle/guzzle:~3.7.",
-        "guzzlehttp/guzzle" : "To use GuzzleV5Adapter, require guzzlehttp/guzzle:~5.0."
+        "guzzlehttp/guzzle" : "To use GuzzleV5Adapter or GuzzleV6Adapter, require guzzlehttp/guzzle:>=5.0,<7.0."
     },
 
     "autoload": {

--- a/src/Adapter/Guzzle6Adapter.php
+++ b/src/Adapter/Guzzle6Adapter.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace DigitalOceanV2\Adapter;
+
+use DigitalOceanV2\Exception\ExceptionInterface;
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+
+class Guzzle6Adapter extends AbstractAdapter implements AdapterInterface
+{
+    /**
+     * @var ClientInterface
+     */
+    protected $client;
+
+    /**
+     * @var ResponseInterface
+     */
+    protected $response;
+
+    /**
+     * @var ExceptionInterface
+     */
+    protected $exception;
+
+    /**
+     * @param string             $accessToken
+     * @param ClientInterface    $client      (optional)
+     * @param ExceptionInterface $exception   (optional)
+     */
+    public function __construct($accessToken, ClientInterface $client = null, ExceptionInterface $exception = null)
+    {
+        $this->client    = $client ?: new \GuzzleHttp\Client(['headers' => [
+           'Authorization' =>  sprintf('Bearer %s', $accessToken)
+        ]]);
+        $this->exception = $exception;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($url)
+    {
+        try {
+            $this->response = $this->client->get($url);
+        } catch (RequestException $e) {
+            throw $this->handleResponse( $e->getResponse() );
+        }
+
+        return $this->response->getBody();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete($url, array $headers = array())
+    {
+        try {
+            $options = array('headers' => $headers);
+            $this->response = $this->client->delete($url, $options);
+        } catch (RequestException $e) {
+            throw $this->handleResponse( $e->getResponse() );
+        }
+
+        return $this->response->getBody();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function put($url, array $headers = array(), $content = '')
+    {
+        try {
+            $options = array('headers' => $headers, 'body' => $content);
+            $this->response = $this->client->put($url, $options);
+        } catch (RequestException $e) {
+            throw $this->handleResponse( $e->getResponse() );
+        }
+
+        return $this->response->getBody();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function post($url, array $headers = array(), $content = '')
+    {
+        try {
+            $options = array('headers' => $headers, 'body' => $content);
+            $this->response = $this->client->post($url, $options);
+        } catch (RequestException $e) {
+            throw $this->handleResponse( $e->getResponse() );
+        }
+
+        return $this->response->getBody();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLatestResponseHeaders()
+    {
+        if (null === $this->response) {
+            return;
+        }
+
+        return array(
+            'reset'     => (int) (string) $this->response->getHeader('RateLimit-Reset'),
+            'remaining' => (int) (string) $this->response->getHeader('RateLimit-Remaining'),
+            'limit'     => (int) (string) $this->response->getHeader('RateLimit-Limit'),
+        );
+    }
+
+    /**
+     * @param Response $response
+     * @return ExceptionInterface|\RuntimeException
+     */
+    protected function handleResponse(Response $response)
+    {
+        $body = $this->response->getBody();
+        $code = $this->response->getStatusCode();
+
+        if ($this->exception) {
+            return $this->exception->create($body, $code);
+        }
+
+        $content = $this->response->json();
+
+        return new \RuntimeException(sprintf('[%d] %s (%s)', $code, $content->message, $content->id), $code);
+    }
+}


### PR DESCRIPTION
Due to how composer works, Guzzle 6 will  be the preferred install for users of php 5.5+. Users of php 5.4 will get Guzzle 5.

Both adapters are now supported however.

The Guzzle5Adapter never had a phpspec created to my knowledge, the same is true for Guzzle6Adapter (problem for another day!).

The changes between Guzzle 5 and 6 are minor enough for how this package uses it, luckily.