### PR TITLE
Return proper response when creating multiple droplets.

### DIFF
--- a/spec/DigitalOceanV2/Api/DropletSpec.php
+++ b/spec/DigitalOceanV2/Api/DropletSpec.php
@@ -281,7 +281,7 @@ class DropletSpec extends \PhpSpec\ObjectBehavior
                 'https://api.digitalocean.com/v2/droplets',
                 ['names' => ['foo', 'bar'], 'region' => 'nyc1', 'size' => '512mb', 'image' => 123456, 'backups' => 'false', 'ipv6' => 'false', 'private_networking' => 'false']
             )
-            ->willReturn('{"droplet": {}}');
+            ->willReturn('{"droplets": {}}');
 
         $this->create(['foo', 'bar'], 'nyc1', '512mb', 123456)->shouldReturn(null);
     }

--- a/src/Api/Droplet.php
+++ b/src/Api/Droplet.php
@@ -138,11 +138,13 @@ class Droplet extends AbstractApi
 
         $droplet = $this->adapter->post(sprintf('%s/droplets', $this->endpoint), $data);
 
-        if (is_array($names)) {
-            return;
-        }
-
         $droplet = json_decode($droplet);
+
+        if (is_array($names)) {
+            return array_map(function ($droplet) {
+                return new DropletEntity($droplet);
+            }, $droplet->droplets);
+        }
 
         return new DropletEntity($droplet->droplet);
     }


### PR DESCRIPTION
When creating multiple droplets using the API client by supplying an array as name attribute, the API will respond accordingly as explained in the docs:

https://developers.digitalocean.com/documentation/v2/#create-multiple-droplets

It would be nice to have a proper response from the client instead of the current _null_ return value...

A patch for this can be found in this pull request.