### PR TITLE
Support for Block Storage

### DIFF
--- a/spec/DigitalOceanV2/Api/VolumeSpec.php
+++ b/spec/DigitalOceanV2/Api/VolumeSpec.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace spec\DigitalOceanV2\Api;
+
+use DigitalOceanV2\Adapter\AdapterInterface;
+
+class VolumeSpec extends \PhpSpec\ObjectBehavior
+{
+    function let(AdapterInterface $adapter)
+    {
+        $this->beConstructedWith($adapter);
+    }
+
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('DigitalOceanV2\Api\Volume');
+    }
+
+    function it_returns_an_empty_array($adapter)
+    {
+        $adapter->get('https://api.digitalocean.com/v2/volumes?per_page=200')->willReturn('{"volumes": []}');
+
+        $volumes = $this->getAll();
+        $volumes->shouldBeArray();
+        $volumes->shouldHaveCount(0);
+    }
+
+    function it_returns_an_array_of_volume_entity($adapter)
+    {
+        $total = 1;
+        $response = <<<EOT
+            {"volumes": [
+                {
+                "id": "506f78a4-e098-11e5-ad9f-000f53306ae1",
+                "region": {
+                    "name": "New York 1",
+                    "slug": "nyc1",
+                    "sizes": [
+                    "512mb",
+                    "1gb",
+                    "2gb",
+                    "4gb",
+                    "8gb",
+                    "16gb",
+                    "32gb",
+                    "48gb",
+                    "64gb"
+                    ],
+                    "features": [
+                    "private_networking",
+                    "backups",
+                    "ipv6",
+                    "metadata"
+                    ],
+                    "available": true
+                },
+                "droplet_ids": [
+
+                ],
+                "name": "example",
+                "description": "Block store for examples",
+                "size_gigabytes": 10,
+                "created_at": "2016-03-02T17:00:49Z"
+                }
+            ],
+            "links": {
+            },
+            "meta": {
+                "total": 1
+            }
+        }        
+EOT;
+
+        $adapter->get('https://api.digitalocean.com/v2/volumes?per_page=200')
+            ->willReturn($response);
+
+        $volumes = $this->getAll();
+        $volumes->shouldBeArray();
+        $volumes->shouldHaveCount($total);
+                
+        $volumes[0]->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Volume');
+        $volumes[0]->region->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Region');
+        
+        $meta = $this->getMeta();
+        $meta->shouldHaveType('DigitalOceanV2\Entity\Meta');
+        $meta->total->shouldBe($total);
+    }
+}

--- a/spec/DigitalOceanV2/Api/VolumeSpec.php
+++ b/spec/DigitalOceanV2/Api/VolumeSpec.php
@@ -330,4 +330,40 @@ EOT;
 
         $this->shouldThrow(new HttpException('Request not processed.'))->duringCreate('example', 'Block store for examples', 10, 'nyc1');
     }
+
+    function it_deletes_the_volume_with_id_and_returns_nothing($adapter)
+    {
+        $adapter
+            ->delete('https://api.digitalocean.com/v2/volumes/506f78a4-e098-11e5-ad9f-000f53306ae1')
+            ->shouldBeCalled();
+
+        $this->delete('506f78a4-e098-11e5-ad9f-000f53306ae1');
+    }
+
+    function it_throws_an_http_exception_when_trying_to_delete_with_id_inexisting_volume($adapter)
+    {
+        $adapter
+            ->delete('https://api.digitalocean.com/v2/volumes/506f78a4-e098-11e5-ad9f-000f53306ae1')
+            ->willThrow(new HttpException('Request not processed.'));
+
+        $this->shouldThrow(new HttpException('Request not processed.'))->duringDelete('506f78a4-e098-11e5-ad9f-000f53306ae1');
+    }
+
+    function it_deletes_the_volume_with_region_and_drivename_and_returns_nothing($adapter)
+    {
+        $adapter
+            ->delete('https://api.digitalocean.com/v2/volumes?name=example&region=ams1')
+            ->shouldBeCalled();
+
+        $this->deleteWithNameAndRegion('example', 'ams1');
+    }
+
+    function it_throws_an_http_exception_when_trying_to_delete_with_region_and_drivename_inexisting_volume($adapter)
+    {
+        $adapter
+            ->delete('https://api.digitalocean.com/v2/volumes?name=example&region=ams1')
+            ->willThrow(new HttpException('Request not processed.'));
+
+        $this->shouldThrow(new HttpException('Request not processed.'))->duringDeleteWithNameAndRegion('example', 'ams1');
+    }
 }

--- a/spec/DigitalOceanV2/Api/VolumeSpec.php
+++ b/spec/DigitalOceanV2/Api/VolumeSpec.php
@@ -210,4 +210,56 @@ EOT;
         $meta->shouldHaveType('DigitalOceanV2\Entity\Meta');
         $meta->total->shouldBe($total);
     }
+
+    function it_returns_a_volume_entity_with_id($adapter)
+    {
+        $total = 1;
+        $response = <<<EOT
+            {
+                "volume": {
+                    "id": "506f78a4-e098-11e5-ad9f-000f53306ae1",
+                    "region": {
+                    "name": "New York 1",
+                    "slug": "nyc1",
+                    "sizes": [
+                        "512mb",
+                        "1gb",
+                        "2gb",
+                        "4gb",
+                        "8gb",
+                        "16gb",
+                        "32gb",
+                        "48gb",
+                        "64gb"
+                    ],
+                    "features": [
+                        "private_networking",
+                        "backups",
+                        "ipv6",
+                        "metadata"
+                    ],
+                    "available": true
+                    },
+                    "droplet_ids": [
+
+                    ],
+                    "name": "example",
+                    "description": "Block store for examples",
+                    "size_gigabytes": 10,
+                    "created_at": "2016-03-02T17:00:49Z"
+                }
+            }       
+EOT;
+
+        $adapter->get('https://api.digitalocean.com/v2/volumes/506f78a4-e098-11e5-ad9f-000f53306ae1?per_page=200')
+            ->willReturn($response);
+
+        $volume = $this->getById("506f78a4-e098-11e5-ad9f-000f53306ae1");
+                
+        $volume->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Volume');
+        $volume->id->shouldBeEqualTo("506f78a4-e098-11e5-ad9f-000f53306ae1");
+        $volume->name->shouldBeEqualTo("example");
+        $volume->region->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Region');
+        $volume->region->slug->shouldBeEqualTo("nyc1");
+    }
 }

--- a/spec/DigitalOceanV2/Api/VolumeSpec.php
+++ b/spec/DigitalOceanV2/Api/VolumeSpec.php
@@ -85,4 +85,66 @@ EOT;
         $meta->shouldHaveType('DigitalOceanV2\Entity\Meta');
         $meta->total->shouldBe($total);
     }
+
+    function it_returns_an_array_of_volume_entity_with_region($adapter)
+    {
+        $total = 1;
+        $response = <<<EOT
+            {"volumes": [
+                {
+                "id": "506f78a4-e098-11e5-ad9f-000f53306ae1",
+                "region": {
+                    "name": "New York 1",
+                    "slug": "nyc1",
+                    "sizes": [
+                    "512mb",
+                    "1gb",
+                    "2gb",
+                    "4gb",
+                    "8gb",
+                    "16gb",
+                    "32gb",
+                    "48gb",
+                    "64gb"
+                    ],
+                    "features": [
+                    "private_networking",
+                    "backups",
+                    "ipv6",
+                    "metadata"
+                    ],
+                    "available": true
+                },
+                "droplet_ids": [
+
+                ],
+                "name": "example",
+                "description": "Block store for examples",
+                "size_gigabytes": 10,
+                "created_at": "2016-03-02T17:00:49Z"
+                }
+            ],
+            "links": {
+            },
+            "meta": {
+                "total": 1
+            }
+        }        
+EOT;
+
+        $adapter->get('https://api.digitalocean.com/v2/volumes?per_page=200&region=nyc1')
+            ->willReturn($response);
+
+        $volumes = $this->getAll("nyc1");
+        $volumes->shouldBeArray();
+        $volumes->shouldHaveCount($total);
+                
+        $volumes[0]->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Volume');
+        $volumes[0]->region->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Region');
+        $volumes[0]->region->slug->shouldBeEqualTo("nyc1");
+        
+        $meta = $this->getMeta();
+        $meta->shouldHaveType('DigitalOceanV2\Entity\Meta');
+        $meta->total->shouldBe($total);
+    }
 }

--- a/spec/DigitalOceanV2/Api/VolumeSpec.php
+++ b/spec/DigitalOceanV2/Api/VolumeSpec.php
@@ -147,4 +147,67 @@ EOT;
         $meta->shouldHaveType('DigitalOceanV2\Entity\Meta');
         $meta->total->shouldBe($total);
     }
+
+    function it_returns_an_array_of_volume_entity_with_region_and_name($adapter)
+    {
+        $total = 1;
+        $response = <<<EOT
+            {"volumes": [
+                {
+                "id": "506f78a4-e098-11e5-ad9f-000f53306ae1",
+                "region": {
+                    "name": "New York 1",
+                    "slug": "nyc1",
+                    "sizes": [
+                    "512mb",
+                    "1gb",
+                    "2gb",
+                    "4gb",
+                    "8gb",
+                    "16gb",
+                    "32gb",
+                    "48gb",
+                    "64gb"
+                    ],
+                    "features": [
+                    "private_networking",
+                    "backups",
+                    "ipv6",
+                    "metadata"
+                    ],
+                    "available": true
+                },
+                "droplet_ids": [
+
+                ],
+                "name": "example",
+                "description": "Block store for examples",
+                "size_gigabytes": 10,
+                "created_at": "2016-03-02T17:00:49Z"
+                }
+            ],
+            "links": {
+            },
+            "meta": {
+                "total": 1
+            }
+        }        
+EOT;
+
+        $adapter->get('https://api.digitalocean.com/v2/volumes?per_page=200&region=nyc1&name=example')
+            ->willReturn($response);
+
+        $volumes = $this->getByNameAndRegion("example", "nyc1");
+        $volumes->shouldBeArray();
+        $volumes->shouldHaveCount($total);
+                
+        $volumes[0]->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Volume');
+        $volumes[0]->name->shouldBeEqualTo("example");
+        $volumes[0]->region->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Region');
+        $volumes[0]->region->slug->shouldBeEqualTo("nyc1");
+        
+        $meta = $this->getMeta();
+        $meta->shouldHaveType('DigitalOceanV2\Entity\Meta');
+        $meta->total->shouldBe($total);
+    }
 }

--- a/spec/DigitalOceanV2/Api/VolumeSpec.php
+++ b/spec/DigitalOceanV2/Api/VolumeSpec.php
@@ -78,10 +78,10 @@ EOT;
         $volumes = $this->getAll();
         $volumes->shouldBeArray();
         $volumes->shouldHaveCount($total);
-                
+
         $volumes[0]->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Volume');
         $volumes[0]->region->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Region');
-        
+
         $meta = $this->getMeta();
         $meta->shouldHaveType('DigitalOceanV2\Entity\Meta');
         $meta->total->shouldBe($total);
@@ -136,14 +136,14 @@ EOT;
         $adapter->get('https://api.digitalocean.com/v2/volumes?per_page=200&region=nyc1')
             ->willReturn($response);
 
-        $volumes = $this->getAll("nyc1");
+        $volumes = $this->getAll('nyc1');
         $volumes->shouldBeArray();
         $volumes->shouldHaveCount($total);
-                
+
         $volumes[0]->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Volume');
         $volumes[0]->region->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Region');
-        $volumes[0]->region->slug->shouldBeEqualTo("nyc1");
-        
+        $volumes[0]->region->slug->shouldBeEqualTo('nyc1');
+
         $meta = $this->getMeta();
         $meta->shouldHaveType('DigitalOceanV2\Entity\Meta');
         $meta->total->shouldBe($total);
@@ -198,15 +198,15 @@ EOT;
         $adapter->get('https://api.digitalocean.com/v2/volumes?per_page=200&region=nyc1&name=example')
             ->willReturn($response);
 
-        $volumes = $this->getByNameAndRegion("example", "nyc1");
+        $volumes = $this->getByNameAndRegion('example', 'nyc1');
         $volumes->shouldBeArray();
         $volumes->shouldHaveCount($total);
-                
+
         $volumes[0]->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Volume');
-        $volumes[0]->name->shouldBeEqualTo("example");
+        $volumes[0]->name->shouldBeEqualTo('example');
         $volumes[0]->region->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Region');
-        $volumes[0]->region->slug->shouldBeEqualTo("nyc1");
-        
+        $volumes[0]->region->slug->shouldBeEqualTo('nyc1');
+
         $meta = $this->getMeta();
         $meta->shouldHaveType('DigitalOceanV2\Entity\Meta');
         $meta->total->shouldBe($total);
@@ -254,13 +254,13 @@ EOT;
         $adapter->get('https://api.digitalocean.com/v2/volumes/506f78a4-e098-11e5-ad9f-000f53306ae1?per_page=200')
             ->willReturn($response);
 
-        $volume = $this->getById("506f78a4-e098-11e5-ad9f-000f53306ae1");
-                
+        $volume = $this->getById('506f78a4-e098-11e5-ad9f-000f53306ae1');
+
         $volume->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Volume');
-        $volume->id->shouldBeEqualTo("506f78a4-e098-11e5-ad9f-000f53306ae1");
-        $volume->name->shouldBeEqualTo("example");
+        $volume->id->shouldBeEqualTo('506f78a4-e098-11e5-ad9f-000f53306ae1');
+        $volume->name->shouldBeEqualTo('example');
         $volume->region->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Region');
-        $volume->region->slug->shouldBeEqualTo("nyc1");
+        $volume->region->slug->shouldBeEqualTo('nyc1');
     }
 
     function it_returns_the_created_volume_entity($adapter)
@@ -312,12 +312,12 @@ EOT;
         $volume = $this->create('example', 'Block store for examples', 10, 'nyc1');
 
         $volume->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\Volume');
-        $volume->id->shouldBeEqualTo("506f78a4-e098-11e5-ad9f-000f53306ae1");
-        $volume->name->shouldBeEqualTo("example");
-        $volume->description->shouldBeEqualTo("Block store for examples");
-        $volume->description->shouldBeEqualTo("Block store for examples");
+        $volume->id->shouldBeEqualTo('506f78a4-e098-11e5-ad9f-000f53306ae1');
+        $volume->name->shouldBeEqualTo('example');
+        $volume->description->shouldBeEqualTo('Block store for examples');
+        $volume->description->shouldBeEqualTo('Block store for examples');
         $volume->sizeGigabytes->shouldBeEqualTo(10);
-        $volume->region->slug->shouldBeEqualTo("nyc1");
+        $volume->region->slug->shouldBeEqualTo('nyc1');
     }
 
     function it_throws_an_http_exception_if_not_possible_to_create_a_volume($adapter)

--- a/src/Api/Volume.php
+++ b/src/Api/Volume.php
@@ -19,7 +19,8 @@ use DigitalOceanV2\Entity\Volume as VolumeEntity;
 class Volume extends AbstractApi
 {
     /**
-     * @return VolumeEntity[]
+     * @param string $regionSlug restricts results to volumes available in a specific region.
+     * @return VolumeEntity[] Lists all of the Block Storage volumes available.
      */
     public function getAll($regionSlug = NULL)
     {

--- a/src/Api/Volume.php
+++ b/src/Api/Volume.php
@@ -53,4 +53,17 @@ class Volume extends AbstractApi
             return new VolumeEntity($volume);
         }, $volumes->volumes);
     }
+
+    /**
+     * @param string $id
+     * @return VolumeEntity the Block Storage volume with the specified id.
+     */
+    public function getById($id)
+    {
+        $volume = $this->adapter->get(sprintf('%s/volumes/%s?per_page=%d', $this->endpoint, $id, 200));
+
+        $volume = json_decode($volume);
+
+        return new VolumeEntity($volume->volume);
+    }
 }

--- a/src/Api/Volume.php
+++ b/src/Api/Volume.php
@@ -35,4 +35,22 @@ class Volume extends AbstractApi
             return new VolumeEntity($volume);
         }, $volumes->volumes);
     }
+
+    /**
+     * @param string $driveName restricts results to volumes with the specified name.
+     * @param string $regionSlug restricts results to volumes available in a specific region.
+     * @return VolumeEntity[] Lists all of the Block Storage volumes available.
+     */
+    public function getByNameAndRegion($driveName, $regionSlug)
+    {
+        $volumes = $this->adapter->get(sprintf('%s/volumes?per_page=%d&region=%s&name=%s', $this->endpoint, 200, $regionSlug, $driveName));
+
+        $volumes = json_decode($volumes);
+
+        $this->extractMeta($volumes);
+
+        return array_map(function ($volume) {
+            return new VolumeEntity($volume);
+        }, $volumes->volumes);
+    }
 }

--- a/src/Api/Volume.php
+++ b/src/Api/Volume.php
@@ -20,6 +20,7 @@ class Volume extends AbstractApi
 {
     /**
      * @param string $regionSlug restricts results to volumes available in a specific region.
+     *
      * @return VolumeEntity[] Lists all of the Block Storage volumes available.
      */
     public function getAll($regionSlug = NULL)
@@ -39,6 +40,7 @@ class Volume extends AbstractApi
     /**
      * @param string $driveName restricts results to volumes with the specified name.
      * @param string $regionSlug restricts results to volumes available in a specific region.
+     *
      * @return VolumeEntity[] Lists all of the Block Storage volumes available.
      */
     public function getByNameAndRegion($driveName, $regionSlug)
@@ -56,11 +58,38 @@ class Volume extends AbstractApi
 
     /**
      * @param string $id
+     *
      * @return VolumeEntity the Block Storage volume with the specified id.
      */
     public function getById($id)
     {
         $volume = $this->adapter->get(sprintf('%s/volumes/%s?per_page=%d', $this->endpoint, $id, 200));
+
+        $volume = json_decode($volume);
+
+        return new VolumeEntity($volume->volume);
+    }
+
+    /**
+     * @param string $name A human-readable name for the Block Storage volume.
+     * @param string $description Free-form text field to describe a Block Storage volume.
+     * @param string $sizeInGigabytes The size of the Block Storage volume in GiB.
+     * @param string $regionSlug The region where the Block Storage volume will be created.
+     *
+     * @throws HttpException
+     * 
+     * @return VolumeEntity the Block Storage volume that was created.
+     */
+    public function create($name, $description, $sizeInGigabytes, $regionSlug)
+    {
+        $data = [
+            'size_gigabytes' => $sizeInGigabytes,
+            'name' => $name,
+            'description' => $description,
+            'region' => $regionSlug
+        ];
+
+        $volume = $this->adapter->post(sprintf('%s/volumes', $this->endpoint), $data);
 
         $volume = json_decode($volume);
 

--- a/src/Api/Volume.php
+++ b/src/Api/Volume.php
@@ -21,9 +21,10 @@ class Volume extends AbstractApi
     /**
      * @return VolumeEntity[]
      */
-    public function getAll()
+    public function getAll($regionSlug = NULL)
     {
-        $volumes = $this->adapter->get(sprintf('%s/volumes?per_page=%d', $this->endpoint, 200));
+        $regionQueryParameter = is_null($regionSlug) ? "" : sprintf("&region=%s", $regionSlug);
+        $volumes = $this->adapter->get(sprintf('%s/volumes?per_page=%d%s', $this->endpoint, 200, $regionQueryParameter));
 
         $volumes = json_decode($volumes);
 

--- a/src/Api/Volume.php
+++ b/src/Api/Volume.php
@@ -23,9 +23,9 @@ class Volume extends AbstractApi
      *
      * @return VolumeEntity[] Lists all of the Block Storage volumes available.
      */
-    public function getAll($regionSlug = NULL)
+    public function getAll($regionSlug = null)
     {
-        $regionQueryParameter = is_null($regionSlug) ? "" : sprintf("&region=%s", $regionSlug);
+        $regionQueryParameter = is_null($regionSlug) ? '' : sprintf('&region=%s', $regionSlug);
         $volumes = $this->adapter->get(sprintf('%s/volumes?per_page=%d%s', $this->endpoint, 200, $regionQueryParameter));
 
         $volumes = json_decode($volumes);
@@ -38,7 +38,7 @@ class Volume extends AbstractApi
     }
 
     /**
-     * @param string $driveName restricts results to volumes with the specified name.
+     * @param string $driveName  restricts results to volumes with the specified name.
      * @param string $regionSlug restricts results to volumes available in a specific region.
      *
      * @return VolumeEntity[] Lists all of the Block Storage volumes available.
@@ -71,10 +71,10 @@ class Volume extends AbstractApi
     }
 
     /**
-     * @param string $name A human-readable name for the Block Storage volume.
-     * @param string $description Free-form text field to describe a Block Storage volume.
+     * @param string $name            A human-readable name for the Block Storage volume.
+     * @param string $description     Free-form text field to describe a Block Storage volume.
      * @param string $sizeInGigabytes The size of the Block Storage volume in GiB.
-     * @param string $regionSlug The region where the Block Storage volume will be created.
+     * @param string $regionSlug      The region where the Block Storage volume will be created.
      *
      * @throws HttpException
      * 
@@ -86,7 +86,7 @@ class Volume extends AbstractApi
             'size_gigabytes' => $sizeInGigabytes,
             'name' => $name,
             'description' => $description,
-            'region' => $regionSlug
+            'region' => $regionSlug,
         ];
 
         $volume = $this->adapter->post(sprintf('%s/volumes', $this->endpoint), $data);

--- a/src/Api/Volume.php
+++ b/src/Api/Volume.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the DigitalOceanV2 library.
+ *
+ * (c) Antoine Corcy <contact@sbin.dk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DigitalOceanV2\Api;
+
+use DigitalOceanV2\Entity\Volume as VolumeEntity;
+
+/**
+ * @author Yassir Hannoun <yassir.hannoun@gmail.com>
+ */
+class Volume extends AbstractApi
+{
+    /**
+     * @return VolumeEntity[]
+     */
+    public function getAll()
+    {
+        $volumes = $this->adapter->get(sprintf('%s/volumes?per_page=%d', $this->endpoint, 200));
+
+        $volumes = json_decode($volumes);
+
+        $this->extractMeta($volumes);
+
+        return array_map(function ($volume) {
+            return new VolumeEntity($volume);
+        }, $volumes->volumes);
+    }
+}

--- a/src/Api/Volume.php
+++ b/src/Api/Volume.php
@@ -95,4 +95,25 @@ class Volume extends AbstractApi
 
         return new VolumeEntity($volume->volume);
     }
+
+    /**
+     * @param string $id
+     *
+     * @throws HttpException
+     */
+    public function delete($id)
+    {
+        $this->adapter->delete(sprintf('%s/volumes/%s', $this->endpoint, $id));
+    }
+
+    /**
+     * @param string $driveName  restricts the search to volumes with the specified name.
+     * @param string $regionSlug restricts the search to volumes available in a specific region.
+     *
+     * @throws HttpException
+     */
+    public function deleteWithNameAndRegion($driveName, $regionSlug)
+    {
+        $this->adapter->delete(sprintf('%s/volumes?name=%s&region=%s', $this->endpoint, $driveName, $regionSlug));
+    }
 }

--- a/src/Entity/Volume.php
+++ b/src/Entity/Volume.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the DigitalOceanV2 library.
+ *
+ * (c) Antoine Corcy <contact@sbin.dk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DigitalOceanV2\Entity;
+
+/**
+ * @author Yassir Hannoun <yassir.hannoun@gmail.com>
+ */
+final class Volume extends AbstractEntity
+{
+    /**
+     * @var string
+     */
+    public $id;
+
+    /**
+     * @var Region
+     */
+    public $region;
+
+    /**
+     * @var int[]
+     */
+    public $dropletIds = [];
+
+    /**
+     * @var string
+     */
+    public $name;
+
+    /**
+     * @var string
+     */
+    public $description;
+
+    /**
+     * @var int
+     */
+    public $sizeGigabytes;
+
+    /**
+     * @var string
+     */
+    public $createdAt;
+
+
+    /**
+     * @param array $parameters
+     */
+    public function build(array $parameters)
+    {
+        parent::build($parameters);
+        
+        foreach ($parameters as $property => $value) {
+            switch ($property) {
+                case 'region':
+                    if (is_object($value)) {
+                        $this->region = new Region($value);
+                    }
+                    unset($parameters[$property]);
+                    break;
+            }
+        }
+    }
+
+    /**
+     * @param string $createdAt
+     */
+    public function setCreatedAt($createdAt)
+    {
+        $this->createdAt = static::convertDateTime($createdAt);
+    }
+}

--- a/src/Entity/Volume.php
+++ b/src/Entity/Volume.php
@@ -51,14 +51,13 @@ final class Volume extends AbstractEntity
      */
     public $createdAt;
 
-
     /**
      * @param array $parameters
      */
     public function build(array $parameters)
     {
         parent::build($parameters);
-        
+
         foreach ($parameters as $property => $value) {
             switch ($property) {
                 case 'region':


### PR DESCRIPTION
This PR fixes #131 by adding support for all the available features of Block Storage exposed via the API.

- [x] List all volumes
- [x] Create a new volume
- [x] Retrieve an existing volume with either by its ID or by its name and region
- [x] Delete a volume with either by its ID or by its name and region