### PR TITLE
Fixed updating and deleting ssh keys to work with fingerprints as ids

### DIFF
--- a/src/Api/Key.php
+++ b/src/Api/Key.php
@@ -82,7 +82,7 @@ class Key extends AbstractApi
     }
 
     /**
-     * @param int    $id
+     * @param string $id
      * @param string $name
      *
      * @throws HttpException
@@ -91,7 +91,7 @@ class Key extends AbstractApi
      */
     public function update($id, $name)
     {
-        $key = $this->adapter->put(sprintf('%s/account/keys/%d', $this->endpoint, $id), ['name' => $name]);
+        $key = $this->adapter->put(sprintf('%s/account/keys/%s', $this->endpoint, $id), ['name' => $name]);
 
         $key = json_decode($key);
 
@@ -99,12 +99,12 @@ class Key extends AbstractApi
     }
 
     /**
-     * @param int $id
+     * @param string $id
      *
      * @throws HttpException
      */
     public function delete($id)
     {
-        $this->adapter->delete(sprintf('%s/account/keys/%d', $this->endpoint, $id));
+        $this->adapter->delete(sprintf('%s/account/keys/%s', $this->endpoint, $id));
     }
 }


### PR DESCRIPTION
The DO v2 API says you can pass in a fingerprint for an SSH key in the API URL and in place of an API, however this library currently casts the ID as an int when I think a string would be just as sufficient to allow for passing in both an ID int or fingerprint string into the argument to support both use cases without duplicate/redundant methods (updateById and updateByFingerprint) so I've updated the update and delete methods.

https://developers.digitalocean.com/documentation/v2/#update-a-key
https://developers.digitalocean.com/documentation/v2/#destroy-a-key

What do you think @yassirh?