### PR TITLE
Add domain records TTL support

### DIFF
--- a/spec/DigitalOceanV2/Api/DomainRecordSpec.php
+++ b/spec/DigitalOceanV2/Api/DomainRecordSpec.php
@@ -58,6 +58,7 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "data": "@",
                         "priority": null,
                         "port": null,
+                        "ttl" : 1800,
                         "weight": null
                     }
                 }
@@ -92,6 +93,7 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "data": "8.8.8.8",
                         "priority": null,
                         "port": null,
+                        "ttl" : 1800,
                         "weight": null
                     }
                 }
@@ -116,6 +118,7 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "data": "8.8.8.8",
                         "priority": null,
                         "port": null,
+                        "ttl" : 1800,
                         "weight": null
                     }
                 }
@@ -142,6 +145,7 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "data": "hosttarget",
                         "priority": null,
                         "port": null,
+                        "ttl" : 1800,
                         "weight": null
                     }
                 }
@@ -168,6 +172,7 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "data": "whatever",
                         "priority": null,
                         "port": null,
+                        "ttl" : 1800,
                         "weight": null
                     }
                 }
@@ -194,6 +199,7 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "data": "ns1.digitalocean.com.",
                         "priority": null,
                         "port": null,
+                        "ttl" : 1800,
                         "weight": null
                     }
                 }
@@ -220,6 +226,7 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "data": "targethost",
                         "priority": 0,
                         "port": 1,
+                        "ttl" : 1800,
                         "weight": 2
                     }
                 }
@@ -246,6 +253,7 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "data": "127.0.0.1",
                         "priority": 0,
                         "port": null,
+                        "ttl" : 1800,
                         "weight": null
                     }
                 }
@@ -255,6 +263,33 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
             ->create('foo.dk', 'mx', 'new-name', '127.0.0.1', 0)
             ->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\DomainRecord');
     }
+
+
+    function it_returns_the_created_domain_record_with_ttl($adapter)
+    {
+        $adapter
+            ->post(
+                'https://api.digitalocean.com/v2/domains/foo.dk/records',
+                ['name' => '@', 'type' => 'A', 'data' => '8.8.8.8', 'ttl' => '60']
+            )
+            ->willReturn('
+                {
+                    "domain_record": {
+                        "id": 123,
+                        "type": "A",
+                        "name": "@",
+                        "data": "8.8.8.8",
+                        "priority": null,
+                        "port": null,
+                        "ttl" : 60,
+                        "weight": null
+                    }
+                }
+            ');
+
+        $this->create('foo.dk', 'a', '@', '8.8.8.8', null, null, null, 60)->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\DomainRecord');
+    }
+
 
     function it_throws_an_invalid_record_exception_if_unknown_type()
     {
@@ -279,6 +314,7 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "data": "127.0.0.1",
                         "priority": null,
                         "port": null,
+                        "ttl" : 1800,
                         "weight": null
                     }
                 }
@@ -294,7 +330,7 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
         $adapter
             ->put(
                 'https://api.digitalocean.com/v2/domains/foo.dk/records/123',
-                ['name' => 'servicename', 'data' => 'targethost', 'port' => 1, 'weight' => 2]
+                ['name' => 'servicename', 'data' => 'targethost', 'port' => 1, 'weight' => 2, 'ttl' => 60]
             )
             ->willReturn('
                 {
@@ -305,13 +341,14 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "data": "targethost",
                         "priority": 0,
                         "port": 1,
+                        "ttl" : 60,
                         "weight": 2
                     }
                 }
             ');
 
         $this
-            ->updateFields('foo.dk', 123, ['name' => 'servicename', 'data' => 'targethost', 'port' => 1, 'weight' => 2])
+            ->updateFields('foo.dk', 123, ['name' => 'servicename', 'data' => 'targethost', 'port' => 1, 'weight' => 2, 'ttl' => 60])
             ->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\DomainRecord');
     }
 

--- a/src/Api/DomainRecord.php
+++ b/src/Api/DomainRecord.php
@@ -62,12 +62,13 @@ class DomainRecord extends AbstractApi
      * @param int    $priority
      * @param int    $port
      * @param int    $weight
+     * @param int    $ttl
      *
      * @throws HttpException|InvalidRecordException
      *
      * @return DomainRecordEntity
      */
-    public function create($domainName, $type, $name, $data, $priority = null, $port = null, $weight = null)
+    public function create($domainName, $type, $name, $data, $priority = null, $port = null, $weight = null, $ttl = null)
     {
         switch ($type = strtoupper($type)) {
             case 'A':
@@ -100,6 +101,10 @@ class DomainRecord extends AbstractApi
                 throw new InvalidRecordException('The domain record type is invalid.');
         }
 
+        if (null !== $ttl) {
+            $content['ttl'] = $ttl;
+        }
+
         $domainRecord = $this->adapter->post(sprintf('%s/domains/%s/records', $this->endpoint, $domainName), $content);
 
         $domainRecord = json_decode($domainRecord);
@@ -115,12 +120,13 @@ class DomainRecord extends AbstractApi
      * @param int|null    $priority
      * @param int|null    $port
      * @param int|null    $weight
+     * @param int|null    $ttl
      *
      * @throws HttpException
      *
      * @return DomainRecordEntity
      */
-    public function update($domainName, $recordId, $name = null, $data = null, $priority = null, $port = null, $weight = null)
+    public function update($domainName, $recordId, $name = null, $data = null, $priority = null, $port = null, $weight = null, $ttl = null)
     {
         $content = compact('name', 'data', 'priority', 'port', 'weight');
         $content = array_filter($content, function ($val) {

--- a/src/Entity/DomainRecord.php
+++ b/src/Entity/DomainRecord.php
@@ -50,5 +50,10 @@ final class DomainRecord extends AbstractEntity
     /**
      * @var int
      */
+    public $ttl;
+
+    /**
+     * @var int
+     */
     public $weight;
 }


### PR DESCRIPTION
This PR brings TTL support for domain records.

DigtialOcean adds support for domain records TTL to API  v2 - https://developers.digitalocean.com/documentation/changelog/api-v2/configurable-ttl-for-domain-records/

This PR changes preserves BC, though if someone store/cache serialized `\DigitalOceanV2\Entity\DomainRecord`, it's recommended to revalidate cache/store.
 