### PR TITLE
Add support for the CAA DomainRecord type

### DIFF
--- a/spec/DigitalOceanV2/Api/DomainRecordSpec.php
+++ b/spec/DigitalOceanV2/Api/DomainRecordSpec.php
@@ -59,7 +59,9 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "priority": null,
                         "port": null,
                         "ttl" : 1800,
-                        "weight": null
+                        "weight": null,
+                        "flags": null,
+                        "tag": null
                     }
                 }
             ');
@@ -94,7 +96,9 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "priority": null,
                         "port": null,
                         "ttl" : 1800,
-                        "weight": null
+                        "weight": null,
+                        "flags": null,
+                        "tag": null
                     }
                 }
             ');
@@ -119,7 +123,9 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "priority": null,
                         "port": null,
                         "ttl" : 1800,
-                        "weight": null
+                        "weight": null,
+                        "flags": null,
+                        "tag": null
                     }
                 }
             ');
@@ -146,7 +152,9 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "priority": null,
                         "port": null,
                         "ttl" : 1800,
-                        "weight": null
+                        "weight": null,
+                        "flags": null,
+                        "tag": null
                     }
                 }
             ');
@@ -173,7 +181,9 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "priority": null,
                         "port": null,
                         "ttl" : 1800,
-                        "weight": null
+                        "weight": null,
+                        "flags": null,
+                        "tag": null
                     }
                 }
             ');
@@ -200,7 +210,9 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "priority": null,
                         "port": null,
                         "ttl" : 1800,
-                        "weight": null
+                        "weight": null,
+                        "flags": null,
+                        "tag": null
                     }
                 }
             ');
@@ -227,7 +239,9 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "priority": 0,
                         "port": 1,
                         "ttl" : 1800,
-                        "weight": 2
+                        "weight": 2,
+                        "flags": null,
+                        "tag": null
                     }
                 }
             ');
@@ -254,7 +268,9 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "priority": 0,
                         "port": null,
                         "ttl" : 1800,
-                        "weight": null
+                        "weight": null,
+                        "flags": null,
+                        "tag": null
                     }
                 }
             ');
@@ -264,6 +280,34 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
             ->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\DomainRecord');
     }
 
+    function it_returns_the_created_domain_record_type_caa($adapter)
+    {
+        $adapter
+            ->post(
+                'https://api.digitalocean.com/v2/domains/foo.dk/records',
+                ['name' => 'recordname', 'type' => 'CAA', 'data' => 'letsencrypt.org', 'flags' => 10, 'tag' => 'iodef',]
+            )
+            ->willReturn('
+                {
+                    "domain_record": {
+                        "id": 123,
+                        "type": "TXT",
+                        "name": "recordname",
+                        "data": "letsencrypt.org",
+                        "priority": null,
+                        "port": null,
+                        "ttl" : 1800,
+                        "weight": null,
+                        "flags": 10,
+                        "tag": "iodef"
+                    }
+                }
+            ');
+
+        $this
+            ->create('foo.dk', 'caa', 'recordname', 'letsencrypt.org', null, null, null, 10, 'iodef')
+            ->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\DomainRecord');
+    }
 
     function it_returns_the_created_domain_record_with_ttl($adapter)
     {
@@ -281,13 +325,15 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "data": "8.8.8.8",
                         "priority": null,
                         "port": null,
-                        "ttl" : 60,
-                        "weight": null
+                        "weight": null,
+                        "flags": null,
+                        "tag": null,
+                        "ttl": 60
                     }
                 }
             ');
 
-        $this->create('foo.dk', 'a', '@', '8.8.8.8', null, null, null, 60)->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\DomainRecord');
+        $this->create('foo.dk', 'a', '@', '8.8.8.8', null, null, null, null, null, 60)->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\DomainRecord');
     }
 
 
@@ -315,13 +361,15 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "priority": null,
                         "port": 80,
                         "ttl" : 22,
-                        "weight": 2
+                        "weight": 2,
+                        "flags": null,
+                        "tag": null
                     }
                 }
             ');
 
         $this
-            ->update('foo.dk', 456, 'new-name', '127.0.0.1', null, 80, 2, 22)
+            ->update('foo.dk', 456, 'new-name', '127.0.0.1', null, 80, 2, null, null, 22)
             ->shouldReturnAnInstanceOf('DigitalOceanV2\Entity\DomainRecord');
     }
 
@@ -342,7 +390,9 @@ class DomainRecordSpec extends \PhpSpec\ObjectBehavior
                         "priority": 0,
                         "port": 1,
                         "ttl" : 60,
-                        "weight": 2
+                        "weight": 2,
+                        "flags": null,
+                        "tag": null
                     }
                 }
             ');

--- a/src/Api/DomainRecord.php
+++ b/src/Api/DomainRecord.php
@@ -62,13 +62,15 @@ class DomainRecord extends AbstractApi
      * @param int    $priority
      * @param int    $port
      * @param int    $weight
+     * @param int    $flags
+     * @param int    $tag
      * @param int    $ttl
      *
      * @throws HttpException|InvalidRecordException
      *
      * @return DomainRecordEntity
      */
-    public function create($domainName, $type, $name, $data, $priority = null, $port = null, $weight = null, $ttl = null)
+    public function create($domainName, $type, $name, $data, $priority = null, $port = null, $weight = null, $flags = null, $tag = null, $ttl = null)
     {
         switch ($type = strtoupper($type)) {
             case 'A':
@@ -97,6 +99,10 @@ class DomainRecord extends AbstractApi
                 $content = ['type' => $type, 'name' => $name, 'data' => $data, 'priority' => $priority];
                 break;
 
+            case 'CAA':
+                $content = ['type' => $type, 'name' => $name, 'data' => $data, 'flags' => $flags, 'tag' => $tag];
+                break;
+
             default:
                 throw new InvalidRecordException('The domain record type is invalid.');
         }
@@ -120,15 +126,18 @@ class DomainRecord extends AbstractApi
      * @param int|null    $priority
      * @param int|null    $port
      * @param int|null    $weight
+     * @param int|null    $flags
+     * @param int|null    $tag
      * @param int|null    $ttl
      *
      * @throws HttpException
      *
      * @return DomainRecordEntity
      */
-    public function update($domainName, $recordId, $name = null, $data = null, $priority = null, $port = null, $weight = null, $ttl = null)
+    public function update($domainName, $recordId, $name = null, $data = null, $priority = null, $port = null, $weight = null, $flags = null, $tag = null, $ttl = null)
     {
-        $content = compact('name', 'data', 'priority', 'port', 'weight', 'ttl');
+        $content = compact('name', 'data', 'priority', 'port', 'weight', 'flags', 'tag', 'ttl');
+
         $content = array_filter($content, function ($val) {
             return $val !== null;
         });

--- a/src/Entity/DomainRecord.php
+++ b/src/Entity/DomainRecord.php
@@ -56,4 +56,14 @@ final class DomainRecord extends AbstractEntity
      * @var int
      */
     public $weight;
+
+    /**
+     * @var int
+     */
+    public $flags;
+
+    /**
+     * @var string
+     */
+    public $tag;
 }


### PR DESCRIPTION
This PR adds support for the CAA record, documented here: https://developers.digitalocean.com/documentation/v2/#create-a-new-domain-record

Note: this does contain a breaking change due to signature changes in the `create` and `update` methods. Should be merged in the next major new version.

Also sneaked in the changes from #176 🙈 