### PR TITLE
add magic getters and setters to the Entities

### DIFF
--- a/src/Entity/AbstractEntity.php
+++ b/src/Entity/AbstractEntity.php
@@ -18,6 +18,13 @@ namespace DigitalOceanV2\Entity;
 abstract class AbstractEntity
 {
     /**
+     * The model's attributes.
+     *
+     * @var array
+     */
+    protected $attributes = [];
+
+    /**
      * @param \stdClass|array|null $parameters
      */
     public function __construct($parameters = null)
@@ -107,5 +114,28 @@ abstract class AbstractEntity
     protected static function convertToSnakeCase($str)
     {
         return strtolower(implode('_', preg_split('/(?=[A-Z])/', $str)));
+    }
+
+    /**
+     * Dynamically retrieve attributes on the model.
+     *
+     * @param  string  $key
+     * @return mixed
+     */
+    public function __get($key)
+    {
+        return isset($this->attributes[$key]) ? $this->attributes[$key] : null;
+    }
+
+    /**
+     * Dynamically set attributes on the model.
+     *
+     * @param  string  $key
+     * @param  mixed  $value
+     * @return void
+     */
+    public function __set($key, $value)
+    {
+        $this->attributes[$key] = $value;
     }
 }


### PR DESCRIPTION
I created this PR because I started to use this library and couldn't access a TTL value of a domain record.  I came into the repo and saw it was fixed [here](https://github.com/toin0u/DigitalOceanV2/commit/0e37ea226bb523cbf269a1e9dc6b63ef9df329c1), but no release has been made since April.

I feel like a simple getter and setter will solve this problem and prevent PRs like that from being necessary in the future.

I'm not sure how the versioning works on this since there's only the one branch, so I'm just PRing this to master.  If this is accepted I would go through and clean up the entities (take out the now unnecessary properties).

Also, wanted to start a discussion on starting a v3 branch, and bumping the PHP version to 7.0.  Then v2 can live on supporting >=5.4, and we can move on with 7.

Thanks!