### PR TITLE
Don't download the documentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 * text=auto
 
+/documentation export-ignore
 /spec export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore


### PR DESCRIPTION
When fetching zips with composer, we don't need all these files.