### PR TITLE
[4.2] Add missing `$vpcUuid` default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ CHANGE LOG
 ==========
 
 
+## 4.2.1 (UPCOMING)
+
+* Add missing `$vpcUuid` default value
+
+
 ## 4.2.0 (20/02/2021)
 
 * Support VPCs when creating droplets

--- a/src/Api/Droplet.php
+++ b/src/Api/Droplet.php
@@ -104,7 +104,7 @@ class Droplet extends AbstractApi
      *
      * @return DropletEntity|DropletEntity[]|null
      */
-    public function create($names, string $region, string $size, $image, bool $backups = false, bool $ipv6 = false, $vpcUuid, array $sshKeys = [], string $userData = '', bool $monitoring = true, array $volumes = [], array $tags = [])
+    public function create($names, string $region, string $size, $image, bool $backups = false, bool $ipv6 = false, $vpcUuid = false, array $sshKeys = [], string $userData = '', bool $monitoring = true, array $volumes = [], array $tags = [])
     {
         $data = \is_array($names) ? ['names' => $names] : ['name' => $names];
 


### PR DESCRIPTION
The Droplet create method is missing a default value, which triggers an exception when calling the method:
`Required parameter $vpcUuid follows optional parameter $backups`.