### PR TITLE
[4.3] Added description field to Size

### DIFF
--- a/src/Entity/Size.php
+++ b/src/Entity/Size.php
@@ -64,4 +64,9 @@ final class Size extends AbstractEntity
      * @var string[]
      */
     public $regions = [];
+
+    /**
+     * @var string
+     */
+    public $description;
 }


### PR DESCRIPTION
A project I'm working on needs to grab the description (e.g. `Storage-Optimized 1.5x SSD`) property which is coming through in the endpoint but not the `Size` class. This adds it so it's accessible in userland.