### PR TITLE
[4.4] Delete droplets matching tag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ $created = $droplet->create('the-name', 'nyc1', '512mb', 'ubuntu-14-04-x64');
 $droplet->remove(123);
 
 // remove all droplets with a given tag
-$droplet->removeAll('awesome');
+$droplet->removeTagged('awesome');
 
 // return a collection of Kernel entity
 $kernels = $droplet->getAvailableKernels(123);

--- a/README.md
+++ b/README.md
@@ -363,6 +363,9 @@ $created = $droplet->create('the-name', 'nyc1', '512mb', 'ubuntu-14-04-x64');
 // remove the droplet 123
 $droplet->remove(123);
 
+// remove all droplets with a given tag
+$droplet->removeAll('awesome');
+
 // return a collection of Kernel entity
 $kernels = $droplet->getAvailableKernels(123);
 

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -147,12 +147,13 @@ abstract class AbstractApi
      * @param string               $uri
      * @param array                $params
      * @param array<string,string> $headers
+     * @param array<string,string> $queryParams
      *
      * @throws ExceptionInterface
      *
      * @return void
      */
-    protected function delete(string $uri, array $params = [], array $headers = []): void
+    protected function delete(string $uri, array $params = [], array $headers = [], array $queryParams = []): void
     {
         $body = self::prepareJsonBody($params);
 
@@ -160,7 +161,7 @@ abstract class AbstractApi
             $headers = self::addJsonContentType($headers);
         }
 
-        $this->client->getHttpClient()->delete(self::prepareUri($uri), $headers, $body ?? '');
+        $this->client->getHttpClient()->delete(self::prepareUri($uri, $queryParams), $headers, $body ?? '');
     }
 
     /**

--- a/src/Api/Droplet.php
+++ b/src/Api/Droplet.php
@@ -163,6 +163,18 @@ class Droplet extends AbstractApi
     }
 
     /**
+     * @param string $tag
+     *
+     * @throws ExceptionInterface
+     *
+     * @return void
+     */
+    public function removeAll(string $tag): void
+    {
+        $this->delete('droplets', [], [], ['tag_name' => $tag]);
+    }
+
+    /**
      * @param int $id
      *
      * @throws ExceptionInterface

--- a/src/Api/Droplet.php
+++ b/src/Api/Droplet.php
@@ -169,7 +169,7 @@ class Droplet extends AbstractApi
      *
      * @return void
      */
-    public function removeAll(string $tag): void
+    public function removeTagged(string $tag): void
     {
         $this->delete('droplets', [], [], ['tag_name' => $tag]);
     }


### PR DESCRIPTION
Fixes #282 

**Overview**
Allows the deletion of one of more droplets by specifying a tag name.

**Tests**
No changes made to existing test suite. The test suite doesn't appear to cover the execution of individual api-related method calls, therefore not sure of the best approach to updating the existing test suite to provide evidence that this works.

I have executed a somewhat-manual CLI test script to verify that a droplet is deleted as expected when `DigitalOceanV2\Api\Droplet::removeAll()` is called.

I am using this fork in a project and when using the fork to delete a droplet by tag name I am observing the correct behaviour.