### PR TITLE
Changed Domain create to not require ip_address

### DIFF
--- a/src/Api/Domain.php
+++ b/src/Api/Domain.php
@@ -59,12 +59,15 @@ class Domain extends AbstractApi
      *
      * @return DomainEntity
      */
-    public function create(string $name, string $ipAddress)
+    public function create(string $name, string $ipAddress = null)
     {
-        $domain = $this->post('domains', [
+        $data = [
             'name' => $name,
-            'ip_address' => $ipAddress,
-        ]);
+        ];
+        if (null !== $ipAddress) {
+            $data['ip_address'] = $ipAddress;
+        }
+        $domain = $this->post('domains', $data);
 
         return new DomainEntity($domain->domain);
     }

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "phpstan/phpstan": "0.12.81",
+        "phpstan/phpstan": "0.12.82",
         "phpstan/phpstan-deprecation-rules": "0.12.6",
         "phpstan/phpstan-strict-rules": "0.12.9",
         "thecodingmachine/phpstan-strict-rules": "0.12.1",

--- a/vendor-bin/phpunit/composer.json
+++ b/vendor-bin/phpunit/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "phpunit/phpunit": "^8.5.14 || ^9.5.2"
+        "phpunit/phpunit": "^8.5.15 || ^9.5.4"
     },
     "config": {
         "preferred-install": "dist"

--- a/vendor-bin/psalm/composer.json
+++ b/vendor-bin/psalm/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "psalm/phar": "4.6.2"
+        "psalm/phar": "4.6.3"
     },
     "config": {
         "preferred-install": "dist"


### PR DESCRIPTION
Domains no longer require an ip address - https://developers.digitalocean.com/documentation/changelog/api-v2/create-domains-without-providing-an-ip-address/