### PR TITLE
[4.4] Allow domains to be created without ip_address

### DIFF
--- a/src/Api/Domain.php
+++ b/src/Api/Domain.php
@@ -61,10 +61,13 @@ class Domain extends AbstractApi
      */
     public function create(string $name, string $ipAddress)
     {
-        $domain = $this->post('domains', [
+        $data = [
             'name' => $name,
-            'ip_address' => $ipAddress,
-        ]);
+        ];
+        if (null !== $ipAddress) {
+            $data['ip_address'] = $ipAddress;
+        }
+        $domain = $this->post('domains', $data);
 
         return new DomainEntity($domain->domain);
     }

--- a/src/Api/Domain.php
+++ b/src/Api/Domain.php
@@ -52,21 +52,23 @@ class Domain extends AbstractApi
     }
 
     /**
-     * @param string $name
-     * @param string $ipAddress
+     * @param string      $name
+     * @param string|null $ipAddress
      *
      * @throws ExceptionInterface
      *
      * @return DomainEntity
      */
-    public function create(string $name, string $ipAddress)
+    public function create(string $name, ?string $ipAddress = null)
     {
         $data = [
             'name' => $name,
         ];
+
         if (null !== $ipAddress) {
             $data['ip_address'] = $ipAddress;
         }
+
         $domain = $this->post('domains', $data);
 
         return new DomainEntity($domain->domain);


### PR DESCRIPTION
Domains no longer require an ip address - https://developers.digitalocean.com/documentation/changelog/api-v2/create-domains-without-providing-an-ip-address/