### PR TITLE
[4.6] Add missing team info to `Account` entity

### DIFF
--- a/src/Entity/Account.php
+++ b/src/Entity/Account.php
@@ -54,4 +54,31 @@ final class Account extends AbstractEntity
      * @var string
      */
     public $statusMessage;
+
+    /**
+     * @var Team
+     */
+    public $team;
+
+    /**
+     * @param array $parameters
+     *
+     * @return void
+     */
+    public function build(array $parameters): void
+    {
+        foreach ($parameters as $property => $value) {
+            switch ($property) {
+                case 'team':
+                    if (\is_object($value)) {
+                        $this->team = new Team($value);
+                    }
+                    unset($parameters[$property]);
+
+                    break;
+            }
+        }
+
+        parent::build($parameters);
+    }
 }

--- a/src/Entity/Team.php
+++ b/src/Entity/Team.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the DigitalOcean API library.
+ *
+ * (c) Antoine Kirk <contact@sbin.dk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DigitalOceanV2\Entity;
+
+/**
+ * @author Roy de Jong <roy@softwarepunt.nl>
+ */
+final class Team extends AbstractEntity
+{
+    /**
+     * @var string
+     */
+    public $uuid;
+
+    /**
+     * @var string
+     */
+    public $name;
+}


### PR DESCRIPTION
This PR adds the missing `team` property to the Account entity.

Reference: https://docs.digitalocean.com/reference/api/api-reference/#operation/account_get