### PR TITLE
[4.8] Add support to disable installation of DO agent

### DIFF
--- a/src/Api/Droplet.php
+++ b/src/Api/Droplet.php
@@ -99,12 +99,13 @@ class Droplet extends AbstractApi
      * @param bool         $monitoring
      * @param array        $volumes
      * @param array        $tags
+     * @param bool         $disable_agent
      *
      * @throws ExceptionInterface
      *
      * @return DropletEntity|DropletEntity[]|null
      */
-    public function create($names, string $region, string $size, $image, bool $backups = false, bool $ipv6 = false, $vpcUuid = false, array $sshKeys = [], string $userData = '', bool $monitoring = true, array $volumes = [], array $tags = [])
+    public function create($names, string $region, string $size, $image, bool $backups = false, bool $ipv6 = false, $vpcUuid = false, array $sshKeys = [], string $userData = '', bool $monitoring = true, array $volumes = [], array $tags = [], $disable_agent = false)
     {
         $data = \is_array($names) ? ['names' => $names] : ['name' => $names];
 
@@ -116,6 +117,10 @@ class Droplet extends AbstractApi
             'ipv6' => $ipv6 ? 'true' : 'false',
             'monitoring' => $monitoring ? 'true' : 'false',
         ]);
+
+        if ($disable_agent) {
+            $data['with_droplet_agent'] = false;
+        }
 
         if (0 < \count($sshKeys)) {
             $data['ssh_keys'] = $sshKeys;

--- a/src/Api/Droplet.php
+++ b/src/Api/Droplet.php
@@ -99,13 +99,13 @@ class Droplet extends AbstractApi
      * @param bool         $monitoring
      * @param array        $volumes
      * @param array        $tags
-     * @param bool         $disable_agent
+     * @param bool         $disableAgent
      *
      * @throws ExceptionInterface
      *
      * @return DropletEntity|DropletEntity[]|null
      */
-    public function create($names, string $region, string $size, $image, bool $backups = false, bool $ipv6 = false, $vpcUuid = false, array $sshKeys = [], string $userData = '', bool $monitoring = true, array $volumes = [], array $tags = [], $disable_agent = false)
+    public function create($names, string $region, string $size, $image, bool $backups = false, bool $ipv6 = false, $vpcUuid = false, array $sshKeys = [], string $userData = '', bool $monitoring = true, array $volumes = [], array $tags = [], bool $disableAgent = false)
     {
         $data = \is_array($names) ? ['names' => $names] : ['name' => $names];
 
@@ -118,7 +118,7 @@ class Droplet extends AbstractApi
             'monitoring' => $monitoring ? 'true' : 'false',
         ]);
 
-        if ($disable_agent) {
+        if ($disableAgent) {
             $data['with_droplet_agent'] = 'false';
         }
 

--- a/src/Api/Droplet.php
+++ b/src/Api/Droplet.php
@@ -119,7 +119,7 @@ class Droplet extends AbstractApi
         ]);
 
         if ($disable_agent) {
-            $data['with_droplet_agent'] = false;
+            $data['with_droplet_agent'] = 'false';
         }
 
         if (0 < \count($sshKeys)) {


### PR DESCRIPTION
The DigitalOcean agent gets installed automatically, but can be disabled via API by sending:
```
"with_droplet_agent":false
```

This adds a bool $disable_agent to turn that on, as the default is to install it. 

This speeds up launching of droplets, specifically in situations where you are only using them for a short amount of time. 