### PR TITLE
Include rate limit data in ApiLimitExceededException

### DIFF
--- a/src/Exception/ApiLimitExceededException.php
+++ b/src/Exception/ApiLimitExceededException.php
@@ -14,9 +14,19 @@ declare(strict_types=1);
 
 namespace DigitalOceanV2\Exception;
 
+use DigitalOceanV2\Entity\RateLimit;
+
 /**
  * @author Graham Campbell <hello@gjcampbell.co.uk>
  */
 class ApiLimitExceededException extends RuntimeException
 {
+    public RateLimit $rateLimit;
+
+    public function __construct(string $message, int $code, RateLimit $rateLimit)
+    {
+        parent::__construct($message, $code);
+
+        $this->rateLimit = $rateLimit;
+    }
 }

--- a/src/Exception/ApiLimitExceededException.php
+++ b/src/Exception/ApiLimitExceededException.php
@@ -21,9 +21,9 @@ use DigitalOceanV2\Entity\RateLimit;
  */
 class ApiLimitExceededException extends RuntimeException
 {
-    public RateLimit $rateLimit;
+    public ?RateLimit $rateLimit;
 
-    public function __construct(string $message, int $code, RateLimit $rateLimit)
+    public function __construct(string $message, int $code, ?RateLimit $rateLimit = null)
     {
         parent::__construct($message, $code);
 

--- a/tests/HttpClient/Plugin/ExceptionThrowerTest.php
+++ b/tests/HttpClient/Plugin/ExceptionThrowerTest.php
@@ -31,9 +31,9 @@ class ExceptionThrowerTest extends TestCase
     {
         $exceptionThrower = new ExceptionThrower();
 
-        $rateLimitReset = rand();
-        $rateLimitRemaining = rand();
-        $rateLimitLimit = rand();
+        $rateLimitReset = \rand();
+        $rateLimitRemaining = \rand();
+        $rateLimitLimit = \rand();
 
         $request = new Request('GET', 'https://example.com/');
         $response = new Response(

--- a/tests/HttpClient/Plugin/ExceptionThrowerTest.php
+++ b/tests/HttpClient/Plugin/ExceptionThrowerTest.php
@@ -61,7 +61,7 @@ class ExceptionThrowerTest extends TestCase
         $expectedExceptionRateLimit = new RateLimit([
             'reset' => $rateLimitReset,
             'remaining' => $rateLimitRemaining,
-            'limit' => $rateLimitLimit
+            'limit' => $rateLimitLimit,
         ]);
 
         self::assertEquals($expectedExceptionRateLimit, $exception->rateLimit);

--- a/tests/HttpClient/Plugin/ExceptionThrowerTest.php
+++ b/tests/HttpClient/Plugin/ExceptionThrowerTest.php
@@ -21,7 +21,6 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Http\Client\Promise\HttpFulfilledPromise;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\RequestInterface;
 
 /**
  * @author Jon Cram <webigntion@gmail.com>

--- a/tests/HttpClient/Plugin/ExceptionThrowerTest.php
+++ b/tests/HttpClient/Plugin/ExceptionThrowerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the DigitalOcean API library.
+ *
+ * (c) Antoine Kirk <contact@sbin.dk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DigitalOceanV2\Tests\HttpClient\Plugin;
+
+use DigitalOceanV2\Entity\RateLimit;
+use DigitalOceanV2\Exception\ApiLimitExceededException;
+use DigitalOceanV2\HttpClient\Plugin\ExceptionThrower;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Http\Client\Promise\HttpFulfilledPromise;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * @author Jon Cram <webigntion@gmail.com>
+ */
+class ExceptionThrowerTest extends TestCase
+{
+    public function testApiLimitExceededExceptionIncludesRateLimit(): void
+    {
+        $exceptionThrower = new ExceptionThrower();
+
+        $rateLimitReset = rand();
+        $rateLimitRemaining = rand();
+        $rateLimitLimit = rand();
+
+        $request = new Request('GET', 'https://example.com/');
+        $response = new Response(
+            429,
+            [
+                'RateLimit-Reset' => $rateLimitReset,
+                'RateLimit-Remaining' => $rateLimitRemaining,
+                'RateLimit-Limit' => $rateLimitLimit,
+            ]
+        );
+
+        $callable = function () use ($response) {
+            return new HttpFulfilledPromise($response);
+        };
+
+        $exception = null;
+
+        try {
+            $exceptionThrower->handleRequest($request, $callable, $callable);
+        } catch (ApiLimitExceededException $exception) {
+        }
+
+        self::assertInstanceOf(ApiLimitExceededException::class, $exception);
+
+        $expectedExceptionRateLimit = new RateLimit([
+            'reset' => $rateLimitReset,
+            'remaining' => $rateLimitRemaining,
+            'limit' => $rateLimitLimit
+        ]);
+
+        self::assertEquals($expectedExceptionRateLimit, $exception->rateLimit);
+    }
+}


### PR DESCRIPTION
**Overview**
A 429 (api limit exceeded) response includes headers reflecting the state of the rate limit. This state can be exposed by `DigitalOceanV2\Exception\ApiLimitExceededException`. Doing so allows callers to more easily access the rate limit state and act accordingly.

**BC Concerns**
This change adds a new third argument to the `ApiLimitExceededException` constructor.  The new constructor argument is nullable and defaults to null to allow any existing calls to the constructor that may be present in consumers of this package to continue to work.

**Tests**
A new test has been added to verify that an instance of  `ApiLimitExceededException` created via `ExceptionThrower::handleRequest()` contains the relevant rate limit state.

