### PR TITLE
Add `storageSizeMib` to `DatabaseCluster` entity

### DIFF
--- a/src/Api/Database.php
+++ b/src/Api/Database.php
@@ -41,7 +41,7 @@ class Database extends AbstractApi
 
         return \array_map(function ($cluster) {
             return new DatabaseClusterEntity($cluster);
-        }, $clusters->databases);
+        }, $clusters->databases ?? []);
     }
 
     /**

--- a/src/Entity/DatabaseCluster.php
+++ b/src/Entity/DatabaseCluster.php
@@ -100,6 +100,11 @@ final class DatabaseCluster extends AbstractEntity
     public $privateNetworkUuid;
 
     /**
+     * @var int|null
+     */
+    public $storageSizeMib;
+
+    /**
      * @param array $parameters
      *
      * @return void

--- a/src/Entity/DatabaseCluster.php
+++ b/src/Entity/DatabaseCluster.php
@@ -62,11 +62,6 @@ final class DatabaseCluster extends AbstractEntity
 
     public ?int $storageSizeMib;
 
-    /**
-     * @param array $parameters
-     *
-     * @return void
-     */
     public function build(array $parameters): void
     {
         parent::build($parameters);


### PR DESCRIPTION
Also guard against an empty list of clusters that could result in:

```
array_map(): Argument #2 ($array) must be of type array, null given
```