### PR TITLE
Also support types 'custom' and 'snapshot' in Image API

### DIFF
--- a/src/Api/Image.php
+++ b/src/Api/Image.php
@@ -35,7 +35,7 @@ class Image extends AbstractApi
     {
         $query = [];
 
-        if (isset($criteria['type']) && \in_array($criteria['type'], ['distribution', 'application'], true)) {
+        if (isset($criteria['type']) && \in_array($criteria['type'], ['distribution', 'application', 'custom', 'snapshot'], true)) {
             $query['type'] = $criteria['type'];
         }
 


### PR DESCRIPTION
Although not in the official Digital Ocean API documentation, the types 'custom' and 'snapshot' can also be used to filter the image list on.

However, the current implementation does not allow this due to the guard checks in the `Image::getAll()` call.