### PR TITLE
Fixed hydration of the Network class with IPv6 addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ CHANGE LOG
 ==========
 
 
+## 5.0.3 (UPCOMING)
+
+* Fixed hydration of the Network class with IPv6 addresses
+
+
 ## 5.0.2 (04/03/2025)
 
 * Fixed a couple of incorrect property types

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -193,21 +193,9 @@ parameters:
 			path: src/Entity/Droplet.php
 
 		-
-			message: '#^Cannot access property \$cidr on mixed\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: src/Entity/Droplet.php
-
-		-
-			message: '#^Cannot access property \$netmask on mixed\.$#'
-			identifier: property.nonObject
-			count: 2
-			path: src/Entity/Droplet.php
-
-		-
 			message: '#^Cannot access property \$version on mixed\.$#'
 			identifier: property.nonObject
-			count: 2
+			count: 1
 			path: src/Entity/Droplet.php
 
 		-

--- a/src/Entity/Droplet.php
+++ b/src/Entity/Droplet.php
@@ -109,7 +109,7 @@ final class Droplet extends AbstractEntity
                                     'netmask' => null,
                                     'gateway' => $subValue->gateway,
                                     'type' => $subValue->type,
-                                    'cidr' => match(\is_int($subValue->netmask)) {
+                                    'cidr' => match (\is_int($subValue->netmask)) {
                                         true => \sprintf('%s/%d', $subValue->ip_address, $subValue->netmask),
                                         default => $subValue->netmask,
                                     },

--- a/src/Entity/Droplet.php
+++ b/src/Entity/Droplet.php
@@ -103,16 +103,13 @@ final class Droplet extends AbstractEntity
 
                         if (\property_exists($value, 'v6')) {
                             foreach ($value->v6 as $subValue) {
-                                /** @var object{ip_address: string, netmask: int|string, gateway: string, type: string} $subValue */
+                                /** @var object{ip_address: string, netmask: int, gateway: string, type: string} $subValue */
                                 $this->networks[] = new Network((object) [
                                     'ip_address' => $subValue->ip_address,
                                     'netmask' => null,
                                     'gateway' => $subValue->gateway,
                                     'type' => $subValue->type,
-                                    'cidr' => match (\is_int($subValue->netmask)) {
-                                        true => \sprintf('%s/%d', $subValue->ip_address, $subValue->netmask),
-                                        default => $subValue->netmask,
-                                    },
+                                    'cidr' => \sprintf('%s/%d', $subValue->ip_address, $subValue->netmask),
                                     'version' => 6,
                                 ]);
                             }

--- a/src/Entity/Droplet.php
+++ b/src/Entity/Droplet.php
@@ -109,8 +109,10 @@ final class Droplet extends AbstractEntity
                                     'netmask' => null,
                                     'gateway' => $subValue->gateway,
                                     'type' => $subValue->type,
-                                    'cidr' => \is_int($subValue->netmask) ?
-                                        $subValue->ip_address.'/'.$subValue->netmask : $subValue->netmask,
+                                    'cidr' => match(\is_int($subValue->netmask)) {
+                                        true => \sprintf('%s/%d', $subValue->ip_address, $subValue->netmask),
+                                        default => $subValue->netmask,
+                                    },
                                     'version' => 6,
                                 ]);
                             }

--- a/src/Entity/Droplet.php
+++ b/src/Entity/Droplet.php
@@ -103,11 +103,16 @@ final class Droplet extends AbstractEntity
 
                         if (\property_exists($value, 'v6')) {
                             foreach ($value->v6 as $subValue) {
-                                $subValue->version = 6;
-                                $subValue->cidr = \is_int($subValue->netmask) ?
-                                    $subValue->ip_address.'/'.$subValue->netmask : $subValue->netmask;
-                                $subValue->netmask = null;
-                                $this->networks[] = new Network($subValue);
+                                /** @var object{ip_address: string, netmask: int|string, gateway: string, type: string} $subValue */
+                                $this->networks[] = new Network((object) [
+                                    'ip_address' => $subValue->ip_address,
+                                    'netmask' => null,
+                                    'gateway' => $subValue->gateway,
+                                    'type' => $subValue->type,
+                                    'cidr' => \is_int($subValue->netmask) ?
+                                        $subValue->ip_address.'/'.$subValue->netmask : $subValue->netmask,
+                                    'version' => 6,
+                                ]);
                             }
                         }
                     }

--- a/src/Entity/Droplet.php
+++ b/src/Entity/Droplet.php
@@ -104,7 +104,8 @@ final class Droplet extends AbstractEntity
                         if (\property_exists($value, 'v6')) {
                             foreach ($value->v6 as $subValue) {
                                 $subValue->version = 6;
-                                $subValue->cidr = $subValue->netmask;
+                                $subValue->cidr = \is_int($subValue->netmask) ?
+                                    $subValue->ip_address.'/'.$subValue->netmask : $subValue->netmask;
                                 $subValue->netmask = null;
                                 $this->networks[] = new Network($subValue);
                             }

--- a/tests/DropletEntityTest.php
+++ b/tests/DropletEntityTest.php
@@ -95,6 +95,24 @@ class DropletEntityTest extends TestCase
                 'description' => 'Basic',
             ],
             'size_slug' => 's-1vcpu-1gb',
+            'networks' => (object) [
+                'v4' => [
+                    (object) [
+                        'ip_address' => '10.135.0.3',
+                        'netmask' => '255.255.0.0',
+                        'gateway' => '10.135.0.1',
+                        'type' => 'private',
+                    ],
+                ],
+                'v6' => [
+                    (object) [
+                        'ip_address' => '2001:db8:a::1234:5678',
+                        'netmask' => 64,
+                        'gateway' => '2001:db8:a::1',
+                        'type' => 'public',
+                    ],
+                ],
+            ],
             'region' => (object) [
                 'name' => 'New York 3',
                 'slug' => 'nyc3',


### PR DESCRIPTION
The IPv6 address `2b03:b0c0:2:d0::102e:d001` should have the CIDR notation `2b03:b0c0:2:d0::102e:d001/64`, `2b03:b0c0:0002:00d0:0000:0000:0000:0000/64`.

I'm not 100% sure what the netmask value can be, is it always int? or can it come as string? that's why the check.

I guess this also applies for 4.x versions, it's just that the field not have the constraint there and don't produce this error.