### PR TITLE
Allow nullable properties on DatabaseCluster and Droplet on creation

### DIFF
--- a/src/Entity/DatabaseCluster.php
+++ b/src/Entity/DatabaseCluster.php
@@ -39,7 +39,7 @@ final class DatabaseCluster extends AbstractEntity
     /**
      * @var string[]
      */
-    public array $dbNames = [];
+    public ?array $dbNames = [];
 
     public int $numNodes;
 
@@ -75,8 +75,6 @@ final class DatabaseCluster extends AbstractEntity
                 $this->users = \array_map(fn ($v) => new DatabaseUser($v), $value ?? []);
             } elseif ('maintenanceWindow' === $property) {
                 $this->maintenanceWindow = new DatabaseMaintenanceWindow($value);
-            } elseif ('dbNames' === $property) {
-                $this->dbNames = $value ?? [];
             } elseif (\property_exists($this, $property)) {
                 $this->$property = $value;
             }

--- a/src/Entity/DatabaseCluster.php
+++ b/src/Entity/DatabaseCluster.php
@@ -75,7 +75,7 @@ final class DatabaseCluster extends AbstractEntity
                 $this->users = \array_map(fn ($v) => new DatabaseUser($v), $value ?? []);
             } elseif ('maintenanceWindow' === $property) {
                 $this->maintenanceWindow = new DatabaseMaintenanceWindow($value);
-            } elseif('dbNames' === $property) {
+            } elseif ('dbNames' === $property) {
                 $this->dbNames = $value ?? [];
             } elseif (\property_exists($this, $property)) {
                 $this->$property = $value;

--- a/src/Entity/DatabaseCluster.php
+++ b/src/Entity/DatabaseCluster.php
@@ -72,9 +72,11 @@ final class DatabaseCluster extends AbstractEntity
             } elseif ('privateConnection' === $property) {
                 $this->privateConnection = new DatabaseConnection($value);
             } elseif ('users' === $property) {
-                $this->users = \array_map(fn ($v) => new DatabaseUser($v), $value);
+                $this->users = \array_map(fn ($v) => new DatabaseUser($v), $value ?? []);
             } elseif ('maintenanceWindow' === $property) {
                 $this->maintenanceWindow = new DatabaseMaintenanceWindow($value);
+            } elseif('dbNames' === $property) {
+                $this->dbNames = $value ?? [];
             } elseif (\property_exists($this, $property)) {
                 $this->$property = $value;
             }

--- a/src/Entity/Droplet.php
+++ b/src/Entity/Droplet.php
@@ -86,7 +86,7 @@ final class Droplet extends AbstractEntity
 
     public NextBackupWindow $nextBackupWindow;
 
-    public string $vpcUuid;
+    public ?string $vpcUuid = null;
 
     public function build(array $parameters): void
     {


### PR DESCRIPTION
Fixed issue with null being assigned to typed properties when DO returns cluster with status `creating`.