### PR TITLE
Fix MonitoringMetric.php wrong property types

### DIFF
--- a/src/Entity/MonitoringMetric.php
+++ b/src/Entity/MonitoringMetric.php
@@ -20,7 +20,7 @@ namespace DigitalOceanV2\Entity;
  */
 final class MonitoringMetric extends AbstractEntity
 {
-    public array $data;
+    public object $data;
 
-    public array $status;
+    public string $status;
 }


### PR DESCRIPTION
Fix Error #1
 
"Cannot assign string to property DigitalOceanV2\\Entity\\MonitoringMetric::$status of type array"

Fix Error #2
Cannot assign stdClass to property DigitalOceanV2\\Entity\\MonitoringMetric::$data of type array