### PR TITLE
Fix error on project resources

### DIFF
--- a/src/Entity/ProjectResource.php
+++ b/src/Entity/ProjectResource.php
@@ -27,4 +27,17 @@ final class ProjectResource extends AbstractEntity
     public array $links;
 
     public string $status;
+
+    public function build(array $parameters): void
+    {
+        foreach ($parameters as $property => $value) {
+            $property = static::convertToCamelCase($property);
+
+            if ('links' === $property) {
+                $this->links = get_object_vars($value);
+            } elseif (\property_exists($this, $property)) {
+                $this->$property = $value;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Reproduce steps:
```
<?php

require_once 'vendor/autoload.php';

// create a new DigitalOcean client
$client = new DigitalOceanV2\Client();

// authenticate the client with your access token which can be
// generated at https://cloud.digitalocean.com/settings/applications
$client->authenticate('your_access_token');

$client->projectResource()->getDefaultProjectResources();
```

Error display:
```
Cannot assign stdClass to property DigitalOceanV2\Entity\ProjectResource::$links of type array
```