### PR TITLE
Fix type error when hydrating LoadBalancer

### DIFF
--- a/src/Entity/LoadBalancer.php
+++ b/src/Entity/LoadBalancer.php
@@ -21,7 +21,7 @@ final class LoadBalancer extends AbstractEntity
 {
     public string $id;
 
-    public int $name;
+    public string $name;
 
     public string $ip;
 


### PR DESCRIPTION
The type of LoadBalancer::$name was incorrectly set to `int`. I've updated it to be `string`.