### PR TITLE
AbstractEntity::build(): Fix \stdClass as array type errors.

### DIFF
--- a/src/Entity/AbstractEntity.php
+++ b/src/Entity/AbstractEntity.php
@@ -58,8 +58,31 @@ abstract class AbstractEntity
         foreach ($parameters as $property => $value) {
             $property = static::convertToCamelCase($property);
 
-            if (\property_exists($this, $property)) {
+            if (!\property_exists($this, $property)) {
+                continue;
+            }
+
+            try {
+
                 $this->$property = $value;
+
+            } catch (\Error $error) {
+
+                // If the reason for the error was attempting to set a \stdClass
+                // instance to an array property, try to type cast it to an
+                // array ourselves.
+
+                $reflectedProperty = new \ReflectionProperty($this, $property);
+
+                if (
+                    $reflectedProperty->getType()->getName() !== 'array' ||
+                    !($value instanceof \stdClass)
+                ) {
+                    continue;
+                }
+
+                $this->$property = (array) $value;
+
             }
         }
     }

--- a/src/Entity/AbstractEntity.php
+++ b/src/Entity/AbstractEntity.php
@@ -63,11 +63,8 @@ abstract class AbstractEntity
             }
 
             try {
-
                 $this->$property = $value;
-
             } catch (\Error $error) {
-
                 // If the reason for the error was attempting to set a \stdClass
                 // instance to an array property, try to type cast it to an
                 // array ourselves.
@@ -75,14 +72,13 @@ abstract class AbstractEntity
                 $reflectedProperty = new \ReflectionProperty($this, $property);
 
                 if (
-                    $reflectedProperty->getType()->getName() !== 'array' ||
+                    'array' !== $reflectedProperty->getType()->getName() ||
                     !($value instanceof \stdClass)
                 ) {
                     continue;
                 }
 
                 $this->$property = (array) $value;
-
             }
         }
     }


### PR DESCRIPTION
I've been getting these errors when trying to use the API:

```
PHP Fatal error:  Uncaught TypeError: Cannot assign stdClass to property DigitalOceanV2\Entity\App::$spec of type array in /var/www/html/vendor/toin0u/digitalocean-v2/src/Entity/AbstractEntity.php:62
Stack trace:
#0 /var/www/html/vendor/toin0u/digitalocean-v2/src/Entity/AbstractEntity.php(35): DigitalOceanV2\Entity\AbstractEntity->build()
#1 /var/www/html/vendor/toin0u/digitalocean-v2/src/Api/App.php(41): DigitalOceanV2\Entity\AbstractEntity->__construct()
#2 [internal function]: DigitalOceanV2\Api\App->DigitalOceanV2\Api\{closure}()
#3 /var/www/html/vendor/toin0u/digitalocean-v2/src/Api/App.php(40): array_map()
#4 /var/www/html/vendor/neurocracy/digitalocean-app-platform-commands/src/Commands/ListCommand.php(22): DigitalOceanV2\Api\App->getAll()
#5 /var/www/html/vendor/symfony/console/Command/InvokableCommand.php(52): Neurocracy\DigitalOcean\AppPlatform\Commands\ListCommand->__invoke()
#6 /var/www/html/vendor/symfony/console/Command/Command.php(315): Symfony\Component\Console\Command\InvokableCommand->__invoke()
#7 /var/www/html/vendor/symfony/console/Application.php(1092): Symfony\Component\Console\Command\Command->run()
#8 /var/www/html/vendor/symfony/console/Application.php(359): Symfony\Component\Console\Application->doRunCommand()
#9 /var/www/html/vendor/symfony/console/Application.php(194): Symfony\Component\Console\Application->doRun()
#10 /var/www/html/vendor/neurocracy/digitalocean-app-platform-commands/bin/do-app(13): Symfony\Component\Console\Application->run()
#11 /var/www/html/vendor/bin/do-app(119): include('...')
#12 {main}
  thrown in /var/www/html/vendor/toin0u/digitalocean-v2/src/Entity/AbstractEntity.php on line 62

Fatal error: Uncaught TypeError: Cannot assign stdClass to property DigitalOceanV2\Entity\App::$spec of type array in /var/www/html/vendor/toin0u/digitalocean-v2/src/Entity/AbstractEntity.php:62
Stack trace:
#0 /var/www/html/vendor/toin0u/digitalocean-v2/src/Entity/AbstractEntity.php(35): DigitalOceanV2\Entity\AbstractEntity->build()
#1 /var/www/html/vendor/toin0u/digitalocean-v2/src/Api/App.php(41): DigitalOceanV2\Entity\AbstractEntity->__construct()
#2 [internal function]: DigitalOceanV2\Api\App->DigitalOceanV2\Api\{closure}()
#3 /var/www/html/vendor/toin0u/digitalocean-v2/src/Api/App.php(40): array_map()
#4 /var/www/html/vendor/neurocracy/digitalocean-app-platform-commands/src/Commands/ListCommand.php(22): DigitalOceanV2\Api\App->getAll()
#5 /var/www/html/vendor/symfony/console/Command/InvokableCommand.php(52): Neurocracy\DigitalOcean\AppPlatform\Commands\ListCommand->__invoke()
#6 /var/www/html/vendor/symfony/console/Command/Command.php(315): Symfony\Component\Console\Command\InvokableCommand->__invoke()
#7 /var/www/html/vendor/symfony/console/Application.php(1092): Symfony\Component\Console\Command\Command->run()
#8 /var/www/html/vendor/symfony/console/Application.php(359): Symfony\Component\Console\Application->doRunCommand()
#9 /var/www/html/vendor/symfony/console/Application.php(194): Symfony\Component\Console\Application->doRun()
#10 /var/www/html/vendor/neurocracy/digitalocean-app-platform-commands/bin/do-app(13): Symfony\Component\Console\Application->run()
#11 /var/www/html/vendor/bin/do-app(119): include('...')
#12 {main}
  thrown in /var/www/html/vendor/toin0u/digitalocean-v2/src/Entity/AbstractEntity.php on line 62
Failed to run do-app apps:list: exit status 255
```

At first I thought it was something to do with using `php-http/react-adapter:^4.0` instead of `guzzlehttp/guzzle:^7.9.2` which is what you seem to test against, but given that you use HTTPlug, it shouldn't matter. Guzzle also produces the same error for me, so that seems to make that unlikely to be the cause.

Digging through the code, I figured the best place to handle this would be in `AbstractEntity::build()` because it seems to address similar errors others have encountered and may fix future errors due to the same cause of getting a `\stdClass` and attempting to set that to an `array` typed property. See  #347, #348, and #350.

This is under PHP 8.3.25 and DDEV 1.24.8 so I don't know if the `\stdClass` thing is a quirk of combination of those and/or whatever other packages I'm using, but this allows the API to work correctly for me when I try to get a list of apps, for example.