### PR TITLE
[5.1] Fix Droplet SSH keys docblock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGE LOG
 ## 5.1.0 (UPCOMING)
 
 * Add PHP 8.5 support
+* Fixed the `Droplet::create` SSH keys parameter type documentation
 
 
 ## 5.0.5 (03/05/2025)

--- a/src/Api/Droplet.php
+++ b/src/Api/Droplet.php
@@ -79,7 +79,7 @@ class Droplet extends AbstractApi
     }
 
     /**
-     * @param int[] $sshKeys
+     * @param (int|string)[] $sshKeys
      *
      * @throws ExceptionInterface
      *


### PR DESCRIPTION
Document that Droplet::create accepts SSH key IDs and fingerprints.