### PR TITLE
[5.0] Fix ProjectResource links hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ CHANGE LOG
 ==========
 
 
+## 5.0.6 (UPCOMING)
+
+* Fixed `ProjectResource` links hydration
+
+
 ## 5.0.5 (03/05/2025)
 
 * Fixed `FirewallRuleOutbound` hydration

--- a/src/Entity/ProjectResource.php
+++ b/src/Entity/ProjectResource.php
@@ -27,4 +27,15 @@ final class ProjectResource extends AbstractEntity
     public array $links;
 
     public string $status;
+
+    public function build(array $parameters): void
+    {
+        foreach ($parameters as $property => $value) {
+            if ('links' === static::convertToCamelCase($property) && $value instanceof \stdClass) {
+                $parameters[$property] = \get_object_vars($value);
+            }
+        }
+
+        parent::build($parameters);
+    }
 }

--- a/tests/ProjectResourceEntityTest.php
+++ b/tests/ProjectResourceEntityTest.php
@@ -42,4 +42,23 @@ class ProjectResourceEntityTest extends TestCase
         self::assertSame(['self' => 'https://api.digitalocean.com/v2/droplets/123456789'], $projectResource->links);
         self::assertSame('already_assigned', $projectResource->status);
     }
+
+    public function testConstructorAcceptsApiShapedLinksObject(): void
+    {
+        $projectResource = new ProjectResource([
+            'urn' => 'do:droplet:123456789',
+            'assigned_at' => '2022-08-04T04:26:24Z',
+            'links' => (object) [
+                'self' => 'https://api.digitalocean.com/v2/droplets/123456789',
+            ],
+            'status' => 'already_assigned',
+        ]);
+
+        self::assertInstanceOf(AbstractEntity::class, $projectResource);
+        self::assertInstanceOf(ProjectResource::class, $projectResource);
+        self::assertSame('do:droplet:123456789', $projectResource->urn);
+        self::assertSame('2022-08-04T04:26:24Z', $projectResource->assignedAt);
+        self::assertSame(['self' => 'https://api.digitalocean.com/v2/droplets/123456789'], $projectResource->links);
+        self::assertSame('already_assigned', $projectResource->status);
+    }
 }


### PR DESCRIPTION
## Summary
- Fix ProjectResource links hydration when the API returns a decoded JSON object.
- Add regression coverage while preserving existing array input.
- Supersedes #348.

## Tests
- vendor/bin/phpunit
- vendor/bin/phpstan analyze --no-progress
- docker run -w /data -v "\${PWD}":/data:delegated --entrypoint vendor/bin/psalm.phar --rm registry.gitlab.com/grahamcampbell/php:8.1-cli --no-progress
- docker run -w /data -v "\${PWD}":/data:delegated --entrypoint vendor/bin/psalm.phar --rm registry.gitlab.com/grahamcampbell/php:8.1-cli --set-baseline=psalm-baseline.xml
- docker run -w /data -v "\${PWD}":/data:delegated --entrypoint vendor/bin/phpstan --rm registry.gitlab.com/grahamcampbell/php:8.1-cli analyze --generate-baseline