### PR TITLE
[5.1] Fix Volume hydration with null droplet IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGE LOG
 * Fixed the `Droplet::create` SSH keys parameter type documentation
 * Fixed hydration of object-backed App Platform and project resource fields
 * Fixed `LoadBalancer` hydration and update serialization
+* Fixed `Volume` hydration when `droplet_ids` is null
 
 
 ## 5.0.5 (03/05/2025)

--- a/src/Entity/Volume.php
+++ b/src/Entity/Volume.php
@@ -52,6 +52,8 @@ final class Volume extends AbstractEntity
 
             if ('region' === $property) {
                 $this->region = new Region($value);
+            } elseif ('dropletIds' === $property && null === $value) {
+                $this->dropletIds = [];
             } elseif (\property_exists($this, $property)) {
                 $this->$property = $value;
             }

--- a/tests/Entity/VolumeTest.php
+++ b/tests/Entity/VolumeTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the DigitalOcean API library.
+ *
+ * (c) Antoine Kirk <contact@sbin.dk>
+ * (c) Graham Campbell <hello@gjcampbell.co.uk>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DigitalOceanV2\Tests\Entity;
+
+use DigitalOceanV2\Entity\AbstractEntity;
+use DigitalOceanV2\Entity\Region;
+use DigitalOceanV2\Entity\Volume;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Graham Campbell <hello@gjcampbell.co.uk>
+ */
+class VolumeTest extends TestCase
+{
+    public function testConstructor(): void
+    {
+        $values = [
+            'id' => '506f78a4-e098-11e5-ad9f-000f53306ae1',
+            'region' => [
+                'name' => 'New York 1',
+                'slug' => 'nyc1',
+                'available' => true,
+                'features' => [
+                    'private_networking',
+                ],
+                'sizes' => [
+                    's-1vcpu-1gb',
+                ],
+            ],
+            'droplet_ids' => [3164444],
+            'name' => 'example',
+            'description' => 'Block store for examples',
+            'size_gigabytes' => 10,
+            'created_at' => '2020-03-02T17:00:49Z',
+            'filesystem_type' => 'ext4',
+            'filesystem_label' => 'example',
+            'tags' => [
+                'aninterestingtag',
+            ],
+        ];
+
+        $entity = new Volume($values);
+
+        self::assertInstanceOf(AbstractEntity::class, $entity);
+        self::assertInstanceOf(Volume::class, $entity);
+        self::assertInstanceOf(Region::class, $entity->region);
+        self::assertSame($values['id'], $entity->id);
+        self::assertSame($values['droplet_ids'], $entity->dropletIds);
+        self::assertSame($values['name'], $entity->name);
+        self::assertSame($values['description'], $entity->description);
+        self::assertSame($values['size_gigabytes'], $entity->sizeGigabytes);
+        self::assertSame($values['created_at'], $entity->createdAt);
+        self::assertSame($values['filesystem_type'], $entity->filesystemType);
+        self::assertSame($values['filesystem_label'], $entity->filesystemLabel);
+        self::assertSame($values['tags'], $entity->tags);
+    }
+
+    public function testConstructorAcceptsNullDropletIds(): void
+    {
+        $entity = new Volume([
+            'id' => '506f78a4-e098-11e5-ad9f-000f53306ae1',
+            'region' => [
+                'name' => 'New York 1',
+                'slug' => 'nyc1',
+                'available' => true,
+                'features' => [],
+                'sizes' => [],
+            ],
+            'droplet_ids' => null,
+            'name' => 'example',
+            'description' => 'Block store for examples',
+            'size_gigabytes' => 10,
+            'created_at' => '2020-03-02T17:00:49Z',
+            'filesystem_type' => 'ext4',
+            'filesystem_label' => 'example',
+        ]);
+
+        self::assertSame([], $entity->dropletIds);
+    }
+}


### PR DESCRIPTION
- Normalize null volume `droplet_ids` to an empty array during hydration.
- Add Volume entity coverage for normal and null droplet ID payloads.

Fixes #356.
