### PR TITLE
[5.1] Mark authentication parameters sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGE LOG
 ## 5.1.0 (06/05/2026)
 
 * Add PHP 8.5 support
+* Add sensitive parameter annotations for authentication tokens
 * Add support for listing Droplets by name or type
 * Fixed the `Droplet::create` SSH keys parameter type documentation
 * Fixed hydration of object-backed App Platform and project resource fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@ CHANGE LOG
 ==========
 
 
+## 5.1.1 (UPCOMING)
+
+* Add sensitive parameter annotations for authentication tokens
+
+
 ## 5.1.0 (06/05/2026)
 
 * Add PHP 8.5 support
-* Add sensitive parameter annotations for authentication tokens
 * Add support for listing Droplets by name or type
 * Fixed the `Droplet::create` SSH keys parameter type documentation
 * Fixed hydration of object-backed App Platform and project resource fields

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "php-http/httplug": "^2.4.1",
         "psr/http-client-implementation": "^1.0",
         "psr/http-factory-implementation": "^1.0",
-        "psr/http-message": "^1.1 || ^2.0"
+        "psr/http-message": "^1.1 || ^2.0",
+        "symfony/polyfill-php82": "^1.27"
     },
     "require-dev": {
         "bamarni/composer-bin-plugin": "^1.8.2",

--- a/src/Client.php
+++ b/src/Client.php
@@ -213,7 +213,7 @@ class Client
         return new Vpc($this);
     }
 
-    public function authenticate(string $token): void
+    public function authenticate(#[\SensitiveParameter] string $token): void
     {
         $this->getHttpClientBuilder()->addPlugin(new Authentication($token));
     }

--- a/src/HttpClient/Plugin/Authentication.php
+++ b/src/HttpClient/Plugin/Authentication.php
@@ -34,7 +34,7 @@ final class Authentication implements Plugin
      */
     private readonly string $header;
 
-    public function __construct(string $token)
+    public function __construct(#[\SensitiveParameter] string $token)
     {
         $this->header = \sprintf('Bearer %s', $token);
     }


### PR DESCRIPTION
Mark authentication tokens as sensitive parameters to avoid stack-trace leaks.