### PR TITLE
fix: Add null fallback for firewall rules response

### DIFF
--- a/src/Api/Database.php
+++ b/src/Api/Database.php
@@ -111,7 +111,7 @@ class Database extends AbstractApi
 
         return \array_map(function ($rule) {
             return new DatabaseRuleEntity($rule);
-        }, $rules->rules);
+        }, $rules->rules ?? []);
     }
 
     /**
@@ -146,7 +146,7 @@ class Database extends AbstractApi
 
         return \array_map(function ($backup) {
             return new DatabaseBackupEntity($backup);
-        }, $backups->backups);
+        }, $backups->backups ?? []);
     }
 
     /**
@@ -180,7 +180,7 @@ class Database extends AbstractApi
 
         return \array_map(function ($replica) {
             return new DatabaseReplicaEntity($replica);
-        }, $replicas->replicas);
+        }, $replicas->replicas ?? []);
     }
 
     /**
@@ -228,7 +228,7 @@ class Database extends AbstractApi
 
         return \array_map(function ($user) {
             return new DatabaseUserEntity($user);
-        }, $users->users);
+        }, $users->users ?? []);
     }
 
     /**
@@ -289,7 +289,7 @@ class Database extends AbstractApi
 
         return \array_map(function ($database) {
             return new DatabaseEntity($database);
-        }, $databases->dbs);
+        }, $databases->dbs ?? []);
     }
 
     /**
@@ -333,7 +333,7 @@ class Database extends AbstractApi
 
         return \array_map(function ($pool) {
             return new DatabasePoolEntity($pool);
-        }, $pools->pools);
+        }, $pools->pools ?? []);
     }
 
     /**


### PR DESCRIPTION
### What I have done
Add null coalescing fallback (`?? []`) to above method in Database.php to prevent errors when the API response returns null for rules.
- `getFirewallRules`
- `getBackups`
- `getAllReplicas`
- `getAllUsers`
- `getAllDatabases`
- `getAllConnectionPools`

### Notes
Because there are no existing tests cover the Database API, tests were not included in this PR. 
Happy to add PHPUnit tests if needed! 